### PR TITLE
Make the subscription type labels more consistent

### DIFF
--- a/protocol.html
+++ b/protocol.html
@@ -319,10 +319,10 @@ content: "";
                 <li class="tocline">
                   <a class="tocxref" href="#subscription-types"><span class="secno">4</span> <span class="content">Subscription Types</span></a>
                   <ol>
-                    <li><a href="#websocketsubscription2021"><span class="secno">4.1</span> <span class="content">WebSocketSubscriptionType2021</span></a></li>
+                    <li><a href="#websocketsubscription2021"><span class="secno">4.1</span> <span class="content">WebSocketSubscription2021</span></a></li>
                     <li><a href="#eventsourcesubscription2021"><span class="secno">4.2</span> <span class="content">EventSourceSubscription2021</span></a></li>
-                    <li><a href="#linkeddatanotificationssubscription2021"><span class="secno">4.3</span> <span class="content">LinkedDataNotifications2021</span></a></li>
-                    <li><a href="#webhooksubscription2021"><span class="secno">4.4</span> <span class="content">WebHookSubscriptionType2021</span></a></li>
+                    <li><a href="#linkeddatanotificationssubscription2021"><span class="secno">4.3</span> <span class="content">LinkedDataNotificationsSubscription2021</span></a></li>
+                    <li><a href="#webhooksubscription2021"><span class="secno">4.4</span> <span class="content">WebHookSubscription2021</span></a></li>
                   </ol>
                 </li>
                 <li class="tocline">
@@ -640,7 +640,7 @@ content: "";
                 <ul>
                   <li><a href="#websocketsubscription2021">WebSocketSubscription2021</a></li>
                   <li><a href="#eventsourcesubscription2021">EventSourceSubscription2021</a></li>
-                  <li><a href="#linkeddatanotificationssubscription2021">LinkedDataNotifications2021</a></li>
+                  <li><a href="#linkeddatanotificationssubscription2021">LinkedDataNotificationsSubscription2021</a></li>
                   <li><a href="#webhooksubscription2021">WebHookSubscription2021</a></li>
                 </ul>
               </nav>


### PR DESCRIPTION
This does *not* change the actual RDF types used for these subscription types, but it does change the labels used in the HTML document to refer to these types consistently