### PR TITLE
Indicate that the gateway API is at risk

### DIFF
--- a/protocol.html
+++ b/protocol.html
@@ -507,6 +507,8 @@ content: "";
 
                   <p>Authentication is not required at this endpoint.</p>
 
+                  <p class="advisement">This definition of a gateway API is <em>at risk</em> and will likely be changed in a future version of this document.</p>
+
                   <p>A sample interaction is described below. The type and feature names are included as examples.</p>
 
                   <figure id="notification-gateway-request" class="example listing" rel="schema:hasPart" resource="#notification-gateway-request">


### PR DESCRIPTION
Given https://github.com/solid/notifications/issues/24 and discussion at the 2021-12-16 panel meeting, it is likely that the gateway API will change. This PR simply indicates that the feature, as described, is at risk. This will allow the publication of a ~FPWD of this document while allowing conversation on #24 to proceed in its own timeframe.