### PR TITLE
Add server-subscription-resource-safe-methods

### DIFF
--- a/protocol.html
+++ b/protocol.html
@@ -524,6 +524,10 @@ content: "";
               <section id="notification-subscription" inlist="" rel="schema:hasPart" resource="#notification-subscription">
                 <h3 property="schema:name">Notification Subscription</h3>
                 <div datatype="rdf:HTML" property="schema:description">
+                  <p>A <em>subscription resource</em> is an <em>RDF document</em> [<cite><a class="bibref" href="#bib-rdf11-concepts">RDF11-CONCEPTS</a></cite>] that can hold any information, typically used by clients to find available features (see <a href="#notification-features">Notification Features</a>).</p>
+
+                  <p><span about="" id="server-subscription-resource-safe-methods" rel="spec:requirement" resource="#server-subscription-resource-safe-methods"><span property="spec:statement"><span rel="spec:requirementSubject" resource="spec:Server">Servers</span> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> accept <code>GET</code>, <code>HEAD</code> and <code>OPTIONS</code> requests targeting the subscription resource.</span></span></p>
+
                   <p>The details of subscribing to a particular endpoint depend on the technology used, but all will follow a similar pattern. For WebSockets, this involves sending an authenticated subscription request to the endpoint retrieved as part of the discovery stage.</p>
 
                   <p>The client sends a JSON-LD payload to this endpoint via <code>POST</code>. The only required fields in this interaction are <code>type</code> and <code>topic</code>. <span about="" id="client-subscription-type" rel="spec:requirement" resource="#client-subscription-type"><span property="spec:statement">The <code>type</code> field <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> contain the type of subscription being requested.</span></span> <span about="" id="client-subscription-feature" rel="spec:requirement" resource="#client-subscription-feature"><span property="spec:statement">The <code>topic</code> field <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> contain the URL of the resource a client wishes to subscribe to changes.</span></span></p>


### PR DESCRIPTION
In reply to ACTION https://github.com/solid/notifications-panel/blob/main/meetings/2022-01-27.md#server-accepts-get-head-and-options-requests-targeting-subscription-resource