### PR TITLE
Clarify discovery mechanism as independent of Solid Metadata Resources

### DIFF
--- a/protocol.html
+++ b/protocol.html
@@ -310,7 +310,7 @@ content: "";
                       <a class="tocxref" href="#discovery"><span class="secno">2.1</span> Discovery</a>
                     </li>
                     <li class="tocline">
-                      <a class="tocxref" href="#notification-subscription"><span class="secno">2.2</span> Notification Subscription</a>
+                      <a class="tocxref" href="#subscription"><span class="secno">2.2</span> Subscription</a>
                     </li>
                   </ol>
                 </li>
@@ -413,14 +413,22 @@ content: "";
 
                   <p property="skos:definition">This specification defines the following terms. These terms are referenced throughout this specification.</p>
 
-                  <span rel="skos:hasTopConcept"><span resource="#solid-server-metadata-resource"></span><span resource="#notification-subscription-api"></span></span>
-
                   <dl>
-                    <dt about="#solid-server-metadata-resource" property="skos:prefLabel" typeof="skos:Concept"><dfn id="solid-server-metadata-resource">Solid Server Metadata Resource</dfn></dt>
-                    <dd about="#solid-server-metadata-resource" property="skos:definition">An <em>RDF document</em> [<cite><a class="bibref" href="#bib-rdf11-concepts">RDF11-CONCEPTS</a></cite>] that includes metadata about the Solid server.</dd>
+                    <dt about="#notification-subscription-api" property="skos:prefLabel" typeof="skos:Concept">
+                      <dfn id="notification-subscription-api">Notification Subscription API</dfn>
+                    </dt>
+                    <dd about="#notification-subscription-api" property="skos:definition">
+                      An HTTP URI at which a client can initiate a subscription to notification events
+                      for a particular set of resources [<cite><a class="bibref" href="#bib-rfc7231">RFC7231</a></cite>].
+                    </dd>
 
-                    <dt about="#notification-subscription-api" property="skos:prefLabel" typeof="skos:Concept"><dfn id="notification-subscription-api">Notification Subscription API</dfn></dt>
-                    <dd about="#notification-subscription-api" property="skos:definition">An HTTP URI at which a client can initiate a subscription to notification events for a particular set of resources [<cite><a class="bibref" href="#bib-rfc7231">RFC7231</a></cite>].</dd>
+                    <dt about="#notification-subscription-metadata-resource" property="skos:prefLabel" typeof="skos:Concept">
+                      <dfn id="notification-subscription-metadata-resource">Notification Subscription Metadata Resource</dfn>
+                    </dt>
+                    <dd about="#notification-subscription-metadata-resource" property="skos:definition">
+                      An <em>RDF document</em> [<cite><a class="bibref" href="#bib-rdf11-concepts">RDF11-CONCEPTS</a></cite>]
+                      that includes metadata about the capabilities of a Notification Subscription API.
+                    </dd>
                   </dl>
                 </div>
               </section>
@@ -472,63 +480,115 @@ content: "";
           <section id="protocol" inlist="" rel="schema:hasPart" resource="#protocol">
             <h2 property="schema:name">Protocol</h2>
             <div datatype="rdf:HTML" property="schema:description">
-              <p>The notification protocol involves the <cite><a href="#discovery" rel="cito:discusses">Discovery</a></cite> of the notification capabilities of a Solid Storage and the <cite><a href="#notification-subscription" rel="cito:discusses">Notification Subscription</a></cite> API which clients can use to subscribe to updates from particular resources.</p>
+              <p>
+                The notification protocol includes both the
+                <cite><a href="#discovery" rel="cito:discusses">Discovery</a></cite>
+                of the capabilities of a subscription resource as well as the mechanism for establishing a
+                <cite><a href="#subscription" rel="cito:discusses">Subscription</a></cite>.
+              </p>
 
-              <p><span about="" id="server-representation-jsonld" rel="spec:requirement" resource="#server-representation-jsonld"><span property="spec:statement">A <span rel="spec:requirementSubject" resource="spec:Server">server</span> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> support JSON-LD in these interactions.</span></span></p>
+              <p>
+                Individual subscription types may augment the discovery and
+                subscription requirements of the notification protocol.
+              </p>
 
               <section id="discovery" inlist="" rel="schema:hasPart" resource="#discovery">
                 <h3 property="schema:name">Discovery</h3>
                 <div datatype="rdf:HTML" property="schema:description">
-                  <p>For any resource in a data pod, a client can discover the associated notification capabilities by fetching the <a href="#solid-server-metadata-resource">Solid Server Metadata Resource</a>. This resource can be retrieved by appending <code>/.well-known/solid</code> to the base URL of the data pod.</p>
+                  <p>
+                    <span id="discovery-serialization" rel="spec:requirement" resource="#discovery-serialization">
+                      <span property="spec:statement">
+                        The <span rel="spec:requirementSubject" resource="spec:Server">server</span>
+                        <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> be capable of serializing the
+                        <cite>Notification Subscription Metadata Resource</cite> as
+                        Turtle [<cite><a class="bibref" href="#bib-turtle">TURTLE</a></cite>]
+                        or JSON-LD [<cite><a class="bibref" href="#bib-json-ld11">JSON-LD11</a></cite>].
+                      </span>
+                    </span>
+                  </p>
 
-                  <figure id="solid-server-metadata-resource-request" class="example listing" rel="schema:hasPart" resource="#solid-server-metadata-resource-request">
-                    <p class="example-h"><span>Example</span>: Retrieve Solid Server Metadata Resource.</p>
+                  <h4 property="schema:name">Turtle Serialization</h4>
 
-                    <pre about="#solid-server-metadata-resource-request" property="schema:description" typeof="fabio:Script"><code>GET /.well-known/solid</code></pre>
+                  <p id="discovery-channel-type-turtle" rel="spec:requirement" resource="#discovery-channel-type-turtle">
+                    When serializing the Notification Subscription Metadata Resource as Turtle,
+                    every <code>notify:hasNotificationChannel</code> definition
+                    <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span>
+                    materialize an <code>rdf:type</code> triple, indicating the channel type.
+                  </p>
 
-                    <figcaption property="schema:name">HTTP <code>GET</code> request targeting <code>.well-known/solid</code></figcaption>
-                  </figure>
+                  <p>
+                    A sample representation of this resource might include the following:
+                  </p>
 
-                  <p class="advisement">The use of a <em>well-known</em> resource is based on suggestions to avoid too many HTTP <code>Link</code> headers, but that is not a settled issue.</p>
+                  <figure id="metadata-resource-response-turtle" class="example listing" rel="schema:hasPart" resource="#metadata-resource-response-turtle">
+                    <p class="example-h">
+                      <span>Example</span>: Representation of a Notification Subscription Metadata Resource.
+                    </p>
 
-                  <p><span about="" id="server-metadata-resource-turtle-jsonld" rel="spec:requirement" resource="#server-metadata-resource-turtle-jsonld"><span property="spec:statement">The <span rel="spec:requirementSubject" resource="spec:Server">server</span> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> be capable of serializing the <cite>Solid Server Metadata Resource</cite> as Turtle or JSON-LD [<cite><a class="bibref" href="#bib-turtle">TURTLE</a></cite>] [<cite><a class="bibref" href="#bib-json-ld11">JSON-LD11</a></cite>].</span></span></p>
-
-                  <p>A sample representation of this resource might include the following:</p>
-
-                  <figure id="solid-server-metadata-resource-response" class="example listing" rel="schema:hasPart" resource="#solid-server-metadata-resource-response">
-                    <p class="example-h"><span>Example</span>: Representation of Solid Server Metadata Resource.</p>
-
-                    <pre about="#solid-server-metadata-resource-response" property="schema:description" typeof="fabio:Script"><code>Content-Type: text/turtle</code>
+                    <pre about="#metadata-resource-response-turtle" property="schema:description" typeof="fabio:Script"><code>Content-Type: text/turtle</code>
 <code></code>
-<code>@prefix solid: &lt;http://www.w3.org/ns/solid/terms#&gt; .</code>
 <code>@prefix notify: &lt;http://www.w3.org/ns/solid/notifications#&gt; .</code>
 <code></code>
 <code>&lt;&gt;</code>
-<code>  a solid:StorageMetadata ;</code>
-<code>  notify:hasNotificationChannel &lt;#websocketNotification&gt;, &lt;#webhookNotification&gt; .</code>
+<code>  notify:hasNotificationChannel &lt;#websocketNotification&gt; .</code>
 <code></code>
 <code>&lt;#websocketNotification&gt;</code>
 <code>  a notify:WebSocketSubscription2021 ;</code>
 <code>  notify:subscription &lt;https://websocket.example/subscription&gt; ;</code>
 <code>  notify:features notify:state, notify:rate, notify:expiration .</code>
-<code></code>
-<code>&lt;#webhookNotification&gt;</code>
-<code>  a notify:WebHookSubscription2021 ;</code>
-<code>  notify:subscription &lt;https://webhook.example/subscription&gt; ;</code>
-<code>  notify:features notify:rate, notify:expiration, notify:webhookAuth .</code></pre>
+<code></code></pre>
 
-                    <figcaption property="schema:name"><code>JSON-LD</code> serialization of a Solid Server Metadata Resource</figcaption>
+                    <figcaption property="schema:name"><code>TURTLE</code> serialization of a Notification Subscription Metadata Resource</figcaption>
                   </figure>
 
-                  <p class="advisement">The <cite><a href="https://github.com/solid/notifications-panel">Notifications Panel</a></cite> will need to define a notification vocabulary to support this feature.</p>
-                  <p about="" id="discovery-channel-type" rel="spec:requirement" resource="#discovery-channel-type">For every <code>notify:hasNotificationChannel</code> triple, the Metadata Resource <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> materialize an <code>rdf:type</code> triple, indicating the channel type.</p>
-                  <p about="" id="discovery-channel-uri" rel="spec:requirement" resource="#discovery-channel-uri">For every <code>notify:hasNotificationChannel</code> triple, the Metadata Resource <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> materialize a <code>notify:subscription</code> triple, indicating the channel subscription URI.</p>
-                  <p>A client will use the provided <code>rdf:type</code>, <code>notify:subscription</code>, and any <code>notify:features</code> triples from the Solid Server Metadata Resource to determine which API to use, given its preference for and/or support of the advertised notification protocols.</p>
+                  <p class="advisement">
+                    The <cite><a href="https://github.com/solid/notifications-panel">Notifications Panel</a></cite>
+                    will need to define a notification vocabulary to support this feature.
+                  </p>
+
+                  <h4 property="schema:name">JSON-LD Serialization</h4>
+
+                  <p id="discovery-channel-type-jsonld" rel="spec:requirement" resource="#discovery-channel-type-jsonld">
+                    When serializing the Notification Subscription Metadata Resource as JSON-LD,
+                    the <code>@context</code>field <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span>
+                    be an array containing the value <code>https://www.w3.org/ns/solid/notification/v1</code>.
+                    In addition, for every <code>hasNotificationChannel</code> definition,
+                    the Subscription Metadata Resource <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span>
+                    materialize a <code>type</code> field, indicating the channel type.
+                  </p>
+
+                  <figure id="metadata-resource-response-jsonld" class="example listing" rel="schema:hasPart" resource="#metadata-resource-response-jsonld">
+                    <p class="example-h">
+                      <span>Example</span>: Representation of a Notification Subscription Metadata Resource.
+                    </p>
+
+                    <pre about="#metadata-resource-response" property="schema:description" typeof="fabio:Script"><code>Content-Type: application/ld+json</code>
+  <code></code>
+  <code>{</code>
+  <code>  "@context": [</code>
+  <code>    "https://www.w3.org/ns/solid/notification/v1"</code>
+  <code>  ],</code>
+  <code>  "hasNotificationChannel": [{</code>
+  <code>    "id": "websocketNotification",</code>
+  <code>    "type": ["WebSocketSubscription2021"],</code>
+  <code>    "subscription": "https://websocket.example/subscription",</code>
+  <code>    "features": ["state", "rate", "expiration"]</code>
+  <code>  }]</code>
+  <code>}</code></pre>
+
+                    <figcaption property="schema:name"><code>JSON-LD</code> serialization of a Notification Subscription Metadata Resource</figcaption>
+                  </figure>
+
+                  <p class="advisement">
+                    The <cite><a href="https://github.com/solid/notifications-panel">Notifications Panel</a></cite>
+                    will need to define a JSON-LD context resource to support this feature.
+                  </p>
+
                 </div>
               </section>
 
-              <section id="notification-subscription" inlist="" rel="schema:hasPart" resource="#notification-subscription">
-                <h3 property="schema:name">Notification Subscription</h3>
+              <section id="subscription" inlist="" rel="schema:hasPart" resource="#subscription">
+                <h3 property="schema:name">Subscription</h3>
                 <div datatype="rdf:HTML" property="schema:description">
                   <p>A <em>subscription resource</em> is an <em>RDF document</em> [<cite><a class="bibref" href="#bib-rdf11-concepts">RDF11-CONCEPTS</a></cite>] that can hold any information, typically used by clients to find available features (see <a href="#notification-features">Notification Features</a>).</p>
 

--- a/protocol.html
+++ b/protocol.html
@@ -511,7 +511,7 @@ content: "";
 
                   <p id="discovery-channel-type-turtle" rel="spec:requirement" resource="#discovery-channel-type-turtle">
                     When serializing the Notification Subscription Metadata Resource as Turtle,
-                    every <code>notify:hasNotificationChannel</code> definition
+                    every <code>notify:notificationChannel</code> definition
                     <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span>
                     materialize an <code>rdf:type</code> triple, indicating the channel type.
                   </p>
@@ -530,7 +530,7 @@ content: "";
 <code>@prefix notify: &lt;http://www.w3.org/ns/solid/notifications#&gt; .</code>
 <code></code>
 <code>&lt;&gt;</code>
-<code>  notify:hasNotificationChannel &lt;#websocketNotification&gt; .</code>
+<code>  notify:notificationChannel &lt;#websocketNotification&gt; .</code>
 <code></code>
 <code>&lt;#websocketNotification&gt;</code>
 <code>  a notify:WebSocketSubscription2021 ;</code>
@@ -552,7 +552,7 @@ content: "";
                     When serializing the Notification Subscription Metadata Resource as JSON-LD,
                     the <code>@context</code>field <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span>
                     be an array containing the value <code>https://www.w3.org/ns/solid/notification/v1</code>.
-                    In addition, for every <code>hasNotificationChannel</code> definition,
+                    In addition, for every <code>notificationChannel</code> definition,
                     the Subscription Metadata Resource <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span>
                     materialize a <code>type</code> field, indicating the channel type.
                   </p>
@@ -568,7 +568,7 @@ content: "";
   <code>  "@context": [</code>
   <code>    "https://www.w3.org/ns/solid/notification/v1"</code>
   <code>  ],</code>
-  <code>  "hasNotificationChannel": [{</code>
+  <code>  "notificationChannel": [{</code>
   <code>    "id": "websocketNotification",</code>
   <code>    "type": ["WebSocketSubscription2021"],</code>
   <code>    "subscription": "https://websocket.example/subscription",</code>


### PR DESCRIPTION
This removes the concept of a "Solid Storage Metadata Resource" (which doesn't exist). Should such a concept be introduced in the Solid Protocol, any relationship to notifications can be added there.