### PR TITLE
Guidance to Subscription Type Publishers 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,15 @@ These reports are incubated by the [Solid Notifications Panel](https://github.co
 The Solid Notification Protocol makes it possible to define any number of subscription types.
 The list of subscription types below does not intend to be comprehensive. This list is intended
 to be useful to application developers looking for existing subscription types as well as to
-authors of new subscription types. New subscription types may be added here, but there is no
-requirement to do so.
+authors of new subscription types.
 
 * [WebSocketSubscription2021](https://solid.github.io/notifications/websocket-subscription-2021) Editor's Draft.
 * [StreamingHTTPSubscription2021](https://solid.github.io/notifications/streaming-http-subscription-2021) Editor's Draft.
 * [EventSourceSubscription2021](https://solid.github.io/notifications/eventsource-subscription-2021) Editor's Draft.
 * [LinkedDataNotificationsSubscription2021](https://solid.github.io/notifications/linkeddatanotifications-subscription-2021) Editor's Draft.
 * [WebHookSubscription2021](https://github.com/solid/notifications/blob/main/webhook-subscription.md) Editor's Draft.
+
+New subscription types may be added here, but there is no requirement to do so. Adding a subscription type to the list above aids in its discoverability by the solid community. We request authors of new subscription types to open a PR with this repository, so that the subscription type they have authored can be included in the list above.
 
 ## Diagrams
 

--- a/protocol.html
+++ b/protocol.html
@@ -805,6 +805,12 @@ content: "";
 
                     <figcaption property="schema:name">Subscription request with a custom subscription type.</figcaption>
                   </figure>
+
+                  <p>
+                    While not necessary, we encourage authors to register subscription types with the Solid project, allowing them to be discovered by the Solid community.
+                    The process for registration shall be avaiable at the <a href="https://github.com/solid/notifications">Solid Notifications Protocol Repository</a>
+                  </p>
+
                 </div>
               </section>
 

--- a/protocol.html
+++ b/protocol.html
@@ -808,7 +808,7 @@ content: "";
 
                   <p>
                     While not necessary, we encourage authors to register subscription types with the Solid project, allowing them to be discovered by the Solid community.
-                    The process for registration shall be avaiable at the <a href="https://github.com/solid/notifications">Solid Notifications Protocol Repository</a>
+                    The process for registration shall be available at the <a href="https://github.com/solid/notifications">Solid Notifications repository</a>.
                   </p>
 
                 </div>


### PR DESCRIPTION
We add text guiding Subscription Type publishers to register the Subscription Type information with the Solid project.

This is the first part of the action item on author guidance from the notifications-panel meeting on 31-03-2022, only containing subscription type registration guidance. Guidance on how one might go about creating a new protocol shall be added later (might require us to write a primer first before linking it from the standard).