### PR TITLE
Fix broken link for WebHook subscription type

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ requirement to do so.
 * [StreamingHTTPSubscription2021](https://solid.github.io/notifications/streaming-http-subscription-2021) Editor's Draft.
 * [EventSourceSubscription2021](https://solid.github.io/notifications/eventsource-subscription-2021) Editor's Draft.
 * [LinkedDataNotificationsSubscription2021](https://solid.github.io/notifications/linkeddatanotifications-subscription-2021) Editor's Draft.
-* [WebHookSubscription2021](https://github.com/solid/notifications/blob/main/webhook-subscription.md) Editor's Draft.
+* [WebHookSubscription2021](https://github.com/solid/notifications/blob/main/webhook-subscription-2021.md) Editor's Draft.
 
 ## Diagrams
 


### PR DESCRIPTION
This link is currently broken. This PR fixes it.