### PR TITLE
Use wss scheme in notification-subscription-response example

### DIFF
--- a/websocket-subscription-2021.html
+++ b/websocket-subscription-2021.html
@@ -422,7 +422,7 @@ content: "";
 <code>{</code>
 <code>  "@context": "https://www.w3.org/ns/solid/notification/v1",</code>
 <code>  "type": "WebSocketSubscription2021",</code>
-<code>  "source": "https://websocket.example/?auth=Ys3KiUq"</code>
+<code>  "source": "wss://websocket.example/?auth=Ys3KiUq"</code>
 <code>}</code></pre>
 
                     <figcaption property="schema:name">Response to the <code>POST</code> request including <code>type</code> and <code>source</code>.</figcaption>


### PR DESCRIPTION
"source" is tripping me up. Shouldn't this example use the `wss` scheme instead of `https`?