### PR TITLE
Simplify and clarify introduction

### DIFF
--- a/protocol.html
+++ b/protocol.html
@@ -362,13 +362,9 @@ content: "";
             <div datatype="rdf:HTML" property="schema:description">
               <p><em>This section is non-normative.</em></p>
 
-              <p id="motivation" rel="schema:hasPart" resource="#motivation" typeof="deo:Motivation"><span datatype="rdf:HTML" property="schema:description">The <cite><a href="https://solidproject.org/TR/protocol" rel="cito:describes">Solid Protocol</a></cite> enables HTTP interactions with resources on the Web, and this satisfies many use cases for client applications in the Solid ecosystem. However, for interactive client applications with multiple participants, chat-apps being just one such example, clients often need to rely on polling in order to discover changes in the underlying data.</span></p>
+              <p id="motivation" rel="schema:hasPart" resource="#motivation" typeof="deo:Motivation"><span datatype="rdf:HTML" property="schema:description">The Solid Notification Protocol defines an extensible, HTTP-based framework by which client applications can establish and manage subscriptions to HTTP resource changes.</p>
 
-              <p>A notification API for would complement the Solid Protocol where clients can listen for updates to particular resources. In addition, a notification-based mechanism may reduce latency and load on a resource server.</p>
-
-              <p>One challenge with (near) real-time notifications on the Web involves the diversity of technologies available. WebSockets and EventSource APIs are two options that are widely supported by browsers; ReadableStreams are becoming more widely supported. Furthermore, there are other, more asynchronous models that are relevant in certain cases: <cite>WebHooks</cite>, <cite><a href="https://www.w3.org/TR/websub/">WebSub</a></cite> and <cite><a href="https://www.w3.org/TR/ldn/">Linked Data Notifications</a></cite> are three examples. A major goal of the model described in this document is to make it possible for client applications to navigate the diversity of these technologies while also being open to new notification mechanisms as they emerge.</p>
-
-              <p>Finally, a critically important part of this model is security. Any notification-based API not only needs the same level of security that is found in the Solid Protocol but also the authorization mechanism needs to be consistent.</p>
+              <p>A goal of the protocol defined by this specification is to enable interaction patterns both for cases where an HTTP client maintains an open connection to a subscription (e.g. WebSockets) as well as for cases where a client establishes a subscription and then disconnects.</p>
 
               <p>This specification is for:</p>
 


### PR DESCRIPTION
The [current introduction](https://solid.github.io/notifications/protocol#introduction) is quite verbose and strays into areas that it really doesn't need to address. This attempts to simplify and make the introduction more concise.