### PR TITLE
Simplify flow diagrams

### DIFF
--- a/notifications-flow-protocol.mmd
+++ b/notifications-flow-protocol.mmd
@@ -1,0 +1,10 @@
+sequenceDiagram
+  autonumber
+  participant Subscriber
+  participant Storage Description Resource
+  participant Subscription Resource
+
+  Subscriber ->> Storage Description Resource: Discovery
+  Storage Description Resource ->> Subscriber: Storage Description Resource
+  Subscriber ->> Subscription Resource: Request subscription (with access token)
+  Subscription Resource ->> Subscriber: Subscription response (with subscription information)

--- a/notifications-flow-protocol.mmd
+++ b/notifications-flow-protocol.mmd
@@ -1,10 +1,10 @@
 sequenceDiagram
   autonumber
   participant Subscriber
-  participant Storage Description Resource
+  participant Discovery Resource
   participant Subscription Resource
 
-  Subscriber ->> Storage Description Resource: Discovery
-  Storage Description Resource ->> Subscriber: Storage Description Resource
-  Subscriber ->> Subscription Resource: Request subscription (with access token)
+  Subscriber ->> Discovery Resource: Discovery
+  Discovery Resource ->> Subscriber: Discovery response
+  Subscriber ->> Subscription Resource: Request subscription (with authentication)
   Subscription Resource ->> Subscriber: Subscription response (with subscription information)

--- a/notifications-flow-source.mmd
+++ b/notifications-flow-source.mmd
@@ -1,16 +1,7 @@
 sequenceDiagram
   autonumber
   participant Subscriber
-  participant Storage Metadata Resource
-  participant Subscriptions Container
-  participant Authorization Server
   participant Notifications Source
 
-  Subscriber ->> Storage Metadata Resource: Discovery
-  Storage Metadata Resource ->> Subscriber: Storage Metadata Resource
-  Subscriber ->> Subscriptions Container: Request subscription (with access token)
-  Subscriptions Container ->> Authorization Server: Verify authorization
-  Authorization Server ->> Subscriptions Container: capabilities
-  Subscriptions Container ->> Subscriber: Subscription response (with notifications source)
   Subscriber ->> Notifications Source: Establish connection
   Notifications Source -->> Subscriber: Stream notifications

--- a/notifications-flow-target.mmd
+++ b/notifications-flow-target.mmd
@@ -4,6 +4,6 @@ sequenceDiagram
   participant Notifications Target
 
   loop for each notification
-    Notifications Publisher ->> Notifications Target: Deliver notification
-    Notifications Target ->> Notifications Publisher: 200 OK
+    Notifications Sender ->> Notifications Target: Deliver notification
+    Notifications Target ->> Notifications Sender: 200 OK
   end

--- a/notifications-flow-target.mmd
+++ b/notifications-flow-target.mmd
@@ -1,6 +1,6 @@
 sequenceDiagram
   autonumber
-  participant Notifications Publisher
+  participant Notifications Sender
   participant Notifications Target
 
   loop for each notification

--- a/notifications-flow-target.mmd
+++ b/notifications-flow-target.mmd
@@ -1,12 +1,9 @@
 sequenceDiagram
   autonumber
-  participant Subscriber
+  participant Notifications Publisher
   participant Notifications Target
-  participant Subscription Resource
-  participant Notifications Source
 
   loop for each notification
-    Notifications Source ->> Notifications Target: Deliver notification
+    Notifications Publisher ->> Notifications Target: Deliver notification
+    Notifications Target ->> Notifications Publisher: 200 OK
   end
-  Subscriber ->> Subscription Resource: Unsubscribe (delete subscription)
-  Subscription Resource ->> Subscriber: 204 No Content

--- a/notifications-flow-target.mmd
+++ b/notifications-flow-target.mmd
@@ -2,19 +2,11 @@ sequenceDiagram
   autonumber
   participant Subscriber
   participant Notifications Target
-  participant Storage Metadata Resource
-  participant Subscriptions Container
-  participant Authorization Server
+  participant Subscription Resource
   participant Notifications Source
 
-  Subscriber ->> Storage Metadata Resource: Discovery
-  Storage Metadata Resource ->> Subscriber: Storage Metadata Resource
-  Subscriber ->> Subscriptions Container: Request subscription (with access token)
-  Subscriptions Container ->> Authorization Server: Verify authorization
-  Authorization Server ->> Subscriptions Container: capabilities
-  Subscriptions Container ->> Subscriber: Subscription response (with webid & unsubscribe)
   loop for each notification
     Notifications Source ->> Notifications Target: Deliver notification
   end
-  Subscriber ->> Subscriptions Container: Unsubscribe (delete subscription)
-  Subscriptions Container ->> Subscriber: 204 No Content
+  Subscriber ->> Subscription Resource: Unsubscribe (delete subscription)
+  Subscription Resource ->> Subscriber: 204 No Content

--- a/protocol.html
+++ b/protocol.html
@@ -407,7 +407,7 @@ content: "";
                   <figure id="solid-notifications-flow-target" rel="schema:hasPart" resource="#solid-notifications-flow-target">
                     <img src="notifications-flow-target.mmd.svg" rel="schema:image" width="800" />
 
-                    <figcaption property="schema:name">Solid Notifications Flow, where the publisher connects to the notification target</figcaption>
+                    <figcaption property="schema:name">Solid Notifications Flow, where the sender delivers to the notification target</figcaption>
                   </figure>
                 </div>
               </section>

--- a/protocol.html
+++ b/protocol.html
@@ -399,7 +399,7 @@ content: "";
                   <figure id="solid-notifications-flow-source" rel="schema:hasPart" resource="#solid-notifications-flow-source">
                     <img src="notifications-flow-source.mmd.svg" rel="schema:image" width="800" />
 
-                    <figcaption property="schema:name">Solid Subscription Flow for Connected Clients</figcaption>
+                    <figcaption property="schema:name">Solid Subscription Flow, where the subscriber connects to the notification source</figcaption>
                   </figure>
 
                   <p>Subscription types in which a client establishes a subscription and does not maintain a persistent connection to a Notifications Source are illustrated by the following diagram.</p>
@@ -407,7 +407,7 @@ content: "";
                   <figure id="solid-notifications-flow-target" rel="schema:hasPart" resource="#solid-notifications-flow-target">
                     <img src="notifications-flow-target.mmd.svg" rel="schema:image" width="800" />
 
-                    <figcaption property="schema:name">Solid Notifications Flow for Offline Clients</figcaption>
+                    <figcaption property="schema:name">Solid Notifications Flow, where the publisher connects to the notification target</figcaption>
                   </figure>
                 </div>
               </section>

--- a/protocol.html
+++ b/protocol.html
@@ -385,19 +385,29 @@ content: "";
                 <div datatype="rdf:HTML" property="schema:description">
                   <p><em>This section is non-normative.</em></p>
 
-                  <p>The following diagrams show the high-level interactions involved in <em>source</em> and <em>target</em> flows.
+                  <p>The following diagram shows the high-level interactions involved discovering and establishing a notification subscription.
                      How a client retrieves an access token for step 3 is outside the scope of this document.</p>
+
+                  <figure id="solid-notifications-flow-protocol" rel="schema:hasPart" resource="#solid-notifications-flow-protocol">
+                    <img src="notifications-flow-protocol.mmd.svg" rel="schema:image" width="800" />
+
+                    <figcaption property="schema:name">Solid Notifications Flow</figcaption>
+                  </figure>
+
+                  <p>Subscription types in which a client establishes a subscription and then maintains a persistent connection to a Notifications Source are illustrated by the following diagram.</p>
 
                   <figure id="solid-notifications-flow-source" rel="schema:hasPart" resource="#solid-notifications-flow-source">
                     <img src="notifications-flow-source.mmd.svg" rel="schema:image" width="800" />
 
-                    <figcaption property="schema:name">Solid Notifications Flow (source)</figcaption>
+                    <figcaption property="schema:name">Solid Subscription Flow for Connected Clients</figcaption>
                   </figure>
+
+                  <p>Subscription types in which a client establishes a subscription and does not maintain a persistent connection to a Notifications Source are illustrated by the following diagram.</p>
 
                   <figure id="solid-notifications-flow-target" rel="schema:hasPart" resource="#solid-notifications-flow-target">
                     <img src="notifications-flow-target.mmd.svg" rel="schema:image" width="800" />
 
-                    <figcaption property="schema:name">Solid Notifications Flow (target)</figcaption>
+                    <figcaption property="schema:name">Solid Notifications Flow for Offline Clients</figcaption>
                   </figure>
                 </div>
               </section>

--- a/protocol.html
+++ b/protocol.html
@@ -385,8 +385,7 @@ content: "";
                 <div datatype="rdf:HTML" property="schema:description">
                   <p><em>This section is non-normative.</em></p>
 
-                  <p>The following diagram shows the high-level interactions involved discovering and establishing a notification subscription.
-                     How a client retrieves an access token for step 3 is outside the scope of this document.</p>
+                  <p>The following diagram shows the high-level interactions involved discovering and establishing a notification subscription.</p>
 
                   <figure id="solid-notifications-flow-protocol" rel="schema:hasPart" resource="#solid-notifications-flow-protocol">
                     <img src="notifications-flow-protocol.mmd.svg" rel="schema:image" width="800" />


### PR DESCRIPTION
This simplifies the flow diagrams, removing those actors that are out of scope for this specification and placing the common portions of the flow into its own diagram. And given that `source` and `target` are not defined until later in the document, this uses more generally understood terminology to describe the categories of interaction.

PR towards https://github.com/solid/notifications/issues/77