### PR TITLE
Clarify subscription-resource definition

### DIFF
--- a/protocol.html
+++ b/protocol.html
@@ -411,10 +411,10 @@ content: "";
                     <dd about="#notification-channel" property="skos:definition">A <em>notification channel</em> is an abstract thing which is identified by a URI and whose properties describe the available communication interface and features.</dd>
 
                     <dt about="#notification-channel-resource" property="skos:prefLabel" typeof="skos:Concept"><dfn id="notification-channel-resource">notification channel resource</dfn></dt>
-                    <dd about="#notification-channel-resource" property="skos:definition">An <em>RDF document</em> [<cite><a class="bibref" href="#bib-rdf11-concepts">RDF11-CONCEPTS</a></cite>] that includes information about the capabilities of a notification channel.</dd>
+                    <dd about="#notification-channel-resource" property="skos:definition">An <em>RDF document</em> [<cite><a class="bibref" href="#bib-rdf11-concepts">RDF11-CONCEPTS</a></cite>] that includes information about the capabilities and features of a notification channel.</dd>
 
                     <dt about="#subscription-resource" property="skos:prefLabel" typeof="skos:Concept"><dfn id="subscription-resource">subscription resource</dfn></dt>
-                    <dd about="#subscription-resource" property="skos:definition">A <em>subscription resource</em> is an <em>RDF document</em> [<cite><a class="bibref" href="#bib-rdf11-concepts">RDF11-CONCEPTS</a></cite>] that can hold any information, typically used by clients to discover available features and capabilities (see <a href="#notification-features">Notification Features</a>).</dd>
+                    <dd about="#subscription-resource" property="skos:definition">A <em>subscription resource</em> is an <em>RDF document</em> [<cite><a class="bibref" href="#bib-rdf11-concepts">RDF11-CONCEPTS</a></cite>] that can be used by clients to discover available features and customize the details (see <a href="#notification-features">Notification Features</a>) of a subscription request.</dd>
 
                     <dt about="#subscription-request" property="skos:prefLabel" typeof="skos:Concept"><dfn id="subscription-request">subscription request</dfn></dt>
                     <dd about="#subscription-request" property="skos:definition">A <em>subscription request</em> is an HTTP request that targets a <a href="#subscription-resource">subscription resource</a> made by a subscriber indicating interest to receive updates about a particular resource.</dd>


### PR DESCRIPTION
Updated to indicate that the subscription-resource is used for subscription requests.