### PR TITLE
removed custom webhooks authn

### DIFF
--- a/webhook-subscription-2021.md
+++ b/webhook-subscription-2021.md
@@ -6,7 +6,8 @@ The [Solid Notification Protocol](https://solid.github.io/notifications/protocol
 This specification defines a subscription type that applies these patterns to WebHooks.
 
 ## Status of This Document
-TODO
+
+Version 0.2-rc2
 
 ## 1. Introduction
 _This section is non-normative._


### PR DESCRIPTION
I'm starting it as a draft since it needs some more work.

@jaxoncreed do you think we can break up this document into a spec and a primer?
* spec - would intentionally leave AuthN out of scope, only mentioning Solid-OIDC in a non-normative way.
* primer - would show all the details and use specifically Solid-OIDC to provide complete guidance.

### TODO

* [ ] adjust conformance classes based on #120 