### PR TITLE
Update conformance model

### DIFF
--- a/protocol.html
+++ b/protocol.html
@@ -976,6 +976,7 @@ content: "";
                     <li>Add server notification channel discovery requirements with <code>Link</code> headers: <a href="#server-link-resource-notification-channel"><code>describedby</code></a>, <a href="#server-link-storage-notification-channel"><code>http://www.w3.org/ns/solid/terms#storageDescription</code></a>.</li>
                     <li>Clarify <a href="#authentication-authorization">authentication and authorization</a> as non-normative and encouragement.</li>
                     <li>Clarify server notification channel resource requirement using <a href="#server-notification-channel-resource-jsonld-context">JSON-LD <code>@context</code></a>.</li>
+                    <li>Update <a href="#conformance">Conformance</a> to add <a href="#normative-informative-content">Normative and Information Content</a>, <a href="#classes-of-products">Class of Products</a>, <a href="#specification-category">Specification Category</a>, <a href="#interoperability">Interoperability</a>.</li>
                   </ul>
                 </div>
               </section>

--- a/protocol.html
+++ b/protocol.html
@@ -477,9 +477,18 @@ content: "";
               <section id="conformance" inlist="" rel="schema:hasPart" resource="#conformance">
                 <h3 property="schema:name">Conformance</h3>
                 <div datatype="rdf:HTML" property="schema:description">
-                  <p>All assertions, diagrams, examples, and notes are non-normative, as are all sections explicitly marked non-normative. Everything else is normative.</p>
+                  <p>This section describes the <span about="" rel="spec:conformance" resource="#conformance">conformance model of the Solid Notifications Protocol</span>.</p>
 
-                  <p>The key words “MUST” and “MUST NOT” are to be interpreted as described in <cite><a href="https://tools.ietf.org/html/bcp14" rel="rdfs:seeAlso">BCP 14</a></cite> [<cite><a class="bibref" href="#bib-rfc2119">RFC2119</a></cite>] [<cite><a class="bibref" href="#bib-rfc8174">RFC8174</a></cite>] when, and only when, they appear in all capitals, as shown here.</p>
+                  <section id="normative-informative-content" inlist="" rel="schema:hasPart" resource="#normative-informative-content">
+                    <h4 property="schema:name">Normative and Informative Content</h4>
+                    <div datatype="rdf:HTML" property="schema:description">
+                      <p id="normative-informative-sections">All assertions, diagrams, examples, and notes are non-normative, as are all sections explicitly marked non-normative. Everything else is normative.</p>
+
+                      <p id="requirement-levels">The key words “<span rel="dcterms:subject" resource="spec:MUST">MUST</span>”, “<span rel="dcterms:subject" resource="spec:MUSTNOT">MUST NOT</span>”, “<span rel="dcterms:subject" resource="spec:SHOULD">SHOULD</span>”, and “<span rel="dcterms:subject" resource="spec:MAY">MAY</span>” are to be interpreted as described in <a href="https://tools.ietf.org/html/bcp14">BCP 14</a> [<cite><a class="bibref" href="#bib-rfc2119">RFC2119</a></cite>] [<cite><a class="bibref" href="#bib-rfc8174">RFC8174</a></cite>] when, and only when, they appear in all capitals, as shown here.</p>
+
+                      <p id="advisement-levels">The key words “<span rel="dcterms:subject" resource="spec:strongly-encouraged">strongly encouraged</span>”, “<span rel="dcterms:subject" resource="spec:strongly-discouraged">strongly discouraged</span>”, “<span rel="dcterms:subject" resource="spec:encouraged">encouraged</span>", “<span rel="dcterms:subject" resource="spec:discouraged">discouraged</span>", “<span rel="dcterms:subject" resource="spec:can">can</span>", “<span rel="dcterms:subject" resource="spec:cannot">cannot</span>”, “<span rel="dcterms:subject" resource="spec:could">could</span>”, “<span rel="dcterms:subject" resource="spec:could-not">could not</span>”, “<span rel="dcterms:subject" resource="spec:might">might</span>”, and “<span rel="dcterms:subject" resource="spec:might-not">might not</span>” are used for non-normative content.</p>
+                    </div>
+                  </section>
                 </div>
               </section>
             </div>

--- a/protocol.html
+++ b/protocol.html
@@ -507,6 +507,13 @@ content: "";
                       </dl>
                     </div>
                   </section>
+
+                  <section id="specification-category" inlist="" rel="schema:hasPart spec:specificationCategory" resource="#specification-category" typeof="skos:ConceptScheme">
+                    <h4 property="schema:name skos:prefLabel">Specification Category</h4>
+                    <div datatype="rdf:HTML" property="schema:description">
+                      <p property="skos:definition">The <span about="" rel="spec:specificationCategory" resource="#specification-category">Solid Protocol</span> identifies the following <cite><a href="https://www.w3.org/TR/spec-variability/#spec-cat" rel="dcterms:subject" resource="spec:SpecificationCategory">Specification Category</a></cite> to distinguish the types of conformance: <span rel="skos:hasTopConcept" resource="spec:API">API</span>, <span rel="skos:hasTopConcept" resource="spec:NotationSyntax">Notation/syntax</span>, <span rel="skos:hasTopConcept" resource="spec:SetOfEvents">Set of events</span>, <span rel="skos:hasTopConcept" resource="spec:Protocol">Protocol</span>.</p>
+                    </div>
+                  </section>
                 </div>
               </section>
             </div>

--- a/protocol.html
+++ b/protocol.html
@@ -514,6 +514,15 @@ content: "";
                       <p property="skos:definition">The <span about="" rel="spec:specificationCategory" resource="#specification-category">Solid Protocol</span> identifies the following <cite><a href="https://www.w3.org/TR/spec-variability/#spec-cat" rel="dcterms:subject" resource="spec:SpecificationCategory">Specification Category</a></cite> to distinguish the types of conformance: <span rel="skos:hasTopConcept" resource="spec:API">API</span>, <span rel="skos:hasTopConcept" resource="spec:NotationSyntax">Notation/syntax</span>, <span rel="skos:hasTopConcept" resource="spec:SetOfEvents">Set of events</span>, <span rel="skos:hasTopConcept" resource="spec:Protocol">Protocol</span>.</p>
                     </div>
                   </section>
+
+                  <section id="interoperability" inlist="" rel="schema:hasPart" resource="#interoperability">
+                    <h4 property="schema:name skos:prefLabel">Interoperability</h4>
+                    <div datatype="rdf:HTML" property="schema:description">
+                      <p id="interoperability-resource-server-client">Interoperability of implementations for <a href="#Client" rel="rdfs:seeAlso">clients</a> and <a href="#ResourceServer" rel="rdfs:seeAlso">resource servers</a> is tested by evaluating an implementation’s ability to request and respond to HTTP messages that conform to this specification.</p>
+
+                      <p id="interoperability-notification-server-client">Interoperability of implementations for <a href="#Client" rel="rdfs:seeAlso">clients</a> and <a href="#NotificationServer" rel="rdfs:seeAlso">notification servers</a> is tested by evaluating an implementation’s ability to request and respond to HTTP messages that conform to this specification.</p>
+                    </div>
+                  </section>
                 </div>
               </section>
             </div>

--- a/protocol.html
+++ b/protocol.html
@@ -489,6 +489,24 @@ content: "";
                       <p id="advisement-levels">The key words “<span rel="dcterms:subject" resource="spec:strongly-encouraged">strongly encouraged</span>”, “<span rel="dcterms:subject" resource="spec:strongly-discouraged">strongly discouraged</span>”, “<span rel="dcterms:subject" resource="spec:encouraged">encouraged</span>", “<span rel="dcterms:subject" resource="spec:discouraged">discouraged</span>", “<span rel="dcterms:subject" resource="spec:can">can</span>", “<span rel="dcterms:subject" resource="spec:cannot">cannot</span>”, “<span rel="dcterms:subject" resource="spec:could">could</span>”, “<span rel="dcterms:subject" resource="spec:could-not">could not</span>”, “<span rel="dcterms:subject" resource="spec:might">might</span>”, and “<span rel="dcterms:subject" resource="spec:might-not">might not</span>” are used for non-normative content.</p>
                     </div>
                   </section>
+
+                  <section id="classes-of-products" inlist="" rel="schema:hasPart" resource="#classes-of-products" typeof="skos:ConceptScheme">
+                    <h4 property="schema:name skos:prefLabel">Classes of Products</h4>
+                    <div datatype="rdf:HTML" property="schema:description">
+                      <p property="skos:definition">The <span about="" rel="spec:classesOfProducts" resource="#classes-of-products">Solid Notifications Protocol</span> identifies the following <cite><a href="https://www.w3.org/TR/qaframe-spec/#cop-def" rel="dcterms:subject" resource="spec:ClassesOfProducts">Classes of Products</a></cite> for conforming implementations. These products are referenced throughout this specification.</p>
+
+                      <span rel="skos:hasTopConcept"><span resource="#Client"></span><span resource="#NotificationServer"></span><span resource="#ResourceServer"></span></span>
+
+                      <dl>
+                        <dt about="#Client" property="skos:prefLabel" rel="skos:relatedMatch" resource="spec:Consumer" typeof="skos:Concept"><dfn id="Client">Client</dfn></dt>
+                        <dd about="#Client" property="skos:definition">A <em>client</em> that builds on HTTP <cite>client</cite> [<cite><a class="bibref" href="#bib-rfc7230">RFC7230</a></cite>], [<cite><a class="bibref" href="#bib-rfc7231">RFC7231</a></cite>], and [<cite><a class="bibref" href="#bib-fetch">FETCH</a></cite>] by defining behaviour in terms of fetching across the platform.</dd>
+                        <dt about="#NotificationServer" property="skos:prefLabel" rel="skos:relatedMatch" resource="spec:RespondingAgent" typeof="skos:Concept"><dfn id="NotificationServer">Notification Server</dfn></dt>
+                        <dd about="#NotificationServer" property="skos:definition">A <em>notification server</em> that builds on HTTP <cite>server</cite> [<cite><a class="bibref" href="#bib-rfc7230">RFC7230</a></cite>] and [<cite><a class="bibref" href="#bib-rfc7231">RFC7231</a></cite>].</dd>
+                        <dt about="#ResourceServer" property="skos:prefLabel" rel="skos:relatedMatch" resource="spec:RespondingAgent" typeof="skos:Concept"><dfn id="ResourceServer">Resource Server</dfn></dt>
+                        <dd about="#ResourceServer" property="skos:definition">A <em>resource server</em> that builds on HTTP <cite>server</cite> [<cite><a class="bibref" href="#bib-rfc7230">RFC7230</a></cite>] and [<cite><a class="bibref" href="#bib-rfc7231">RFC7231</a></cite>] by defining media types, HTTP header fields, and the behaviour of resources, as identified by link relations.</dd>
+                      </dl>
+                    </div>
+                  </section>
                 </div>
               </section>
             </div>


### PR DESCRIPTION
This PR develops the under-specified `#conformance` model. Resolves https://github.com/solid/notifications/issues/106 .

The work herein follows the guidelines in https://www.w3.org/TR/spec-variability/ and https://www.w3.org/TR/qaframe-spec/ , and applies http://www.w3.org/ns/spec# .

To simplify the review process, this PR focuses on the `#conformance` section and leaves out updates intended to be throughout the specification corresponding to these changes that will be included in a follow up PR.
