### PR TITLE
Tag WebhookSubscription2021 as Version 0.1

### DIFF
--- a/webhook-subscription-2021.md
+++ b/webhook-subscription-2021.md
@@ -6,7 +6,8 @@ The [Solid Notification Protocol](https://solid.github.io/notifications/protocol
 This specification defines a subscription type that applies these patterns to WebHooks.
 
 ## Status of This Document
-TODO
+
+Version: 0.1
 
 ## 1. Introduction
 _This section is non-normative._

--- a/webhook-subscription-2021.md
+++ b/webhook-subscription-2021.md
@@ -257,3 +257,4 @@ Pods that implement the `webhook-auth` feature `MUST` create an Access Token and
  - The examples in this specification assume that the base domain `https://bob.pod.example` are interchangable with `https://pod.example`. This is not always the case and could lead to security vulnerabilities.
  - Defining a feature that includes the resource or the delta of the changes in the request are beyond the scope of this document, but it's something that should be considered.
  - What is the UUID in the webhook body?
+ 


### PR DESCRIPTION
As discussed and action of meeting: https://github.com/solid/notifications-panel/blob/main/meetings/2022-11-24.md#webhooks

There are existing implementations, including

* https://github.com/o-development/solid-webhook-client
* https://github.com/CommunitySolidServer/CommunitySolidServer/tree/versions/6.0.0

They should be able to reference specific version currently implemented.