### PR TITLE
Align WebSocket diagram to Notification Protocol diagram

### DIFF
--- a/websocket-subscription-2021-flow.mmd
+++ b/websocket-subscription-2021-flow.mmd
@@ -1,16 +1,13 @@
 sequenceDiagram
   autonumber
   participant Subscriber
-  participant Storage Metadata Resource
-  participant Subscriptions Container
-  participant Authorization Server
+  participant Discovery Resource
+  participant Subscription Resource
   participant Notifications Source
 
-  Subscriber ->> Storage Metadata Resource: Discovery
-  Storage Metadata Resource ->> Subscriber: Storage Metadata Resource
-  Subscriber ->> Subscriptions Container: Request WebSocketsSubscription2021 (with access token)
-  Subscriptions Container ->> Authorization Server: Verify authorization
-  Authorization Server ->> Subscriptions Container: capabilities
-  Subscriptions Container ->> Subscriber: Subscription response (with wss: notifications source)
+  Subscriber ->> Discovery Resource: Discovery
+  Discovery Resource ->> Subscriber: Discovery response
+  Subscriber ->> Subscription Resource: Request WebSocketsSubscription2021 (with authentication)
+  Subscription Resource ->> Subscriber: Subscription response (with wss: notifications source)
   Subscriber ->> Notifications Source: Establish WebSockets connection
   Notifications Source -->> Subscriber: Stream notifications

--- a/websocket-subscription-2021.html
+++ b/websocket-subscription-2021.html
@@ -134,7 +134,7 @@ content: "";
     <main>
       <article about="" typeof="schema:Article doap:Specification">
         <h1 property="schema:name">WebSocketSubscription2021</h1>
-        <h2>Editor’s Draft, 2022-05-09</h2>
+        <h2>Editor’s Draft, 2022-12-01</h2>
 
         <details open="">
           <summary>More details about this document</summary>
@@ -168,7 +168,7 @@ content: "";
 
           <dl id="document-modified">
             <dt>Modified</dt>
-            <dd><time content="2022-05-09T00:00:00Z" datatype="xsd:dateTime" datetime="2022-05-09T00:00:00Z" property="schema:dateModified">2022-05-09</time></dd>
+            <dd><time content="2022-12-01T00:00:00Z" datatype="xsd:dateTime" datetime="2022-12-01T00:00:00Z" property="schema:dateModified">2022-12-01</time></dd>
           </dl>
 
           <dl id="document-repository">


### PR DESCRIPTION
This adjusts the current WebSocket subscription type diagram to align with the diagrams in the Notification Protocol document. The updated flow looks like this

![websocket-subscription-2021-flow mmd](https://user-images.githubusercontent.com/1265883/205066892-93f51e4b-333e-47d6-bc3e-60da36dd8a69.svg)
