### PR TITLE
adjust terminology to match product classes

### DIFF
--- a/protocol.html
+++ b/protocol.html
@@ -428,10 +428,10 @@ content: "";
                     <dd about="#notification-channel-resource" property="skos:definition">An <em>RDF document</em> [<cite><a class="bibref" href="#bib-rdf11-concepts">RDF11-CONCEPTS</a></cite>] that includes information about the capabilities and features of a notification channel.</dd>
 
                     <dt about="#subscription-resource" property="skos:prefLabel" typeof="skos:Concept"><dfn id="subscription-resource">subscription resource</dfn></dt>
-                    <dd about="#subscription-resource" property="skos:definition">A <em>subscription resource</em> is an <em>RDF document</em> [<cite><a class="bibref" href="#bib-rdf11-concepts">RDF11-CONCEPTS</a></cite>] that can be used by clients to discover available features and customize the details (see <a href="#notification-features">Notification Features</a>) of a subscription request.</dd>
+                    <dd about="#subscription-resource" property="skos:definition">A <em>subscription resource</em> is an <em>RDF document</em> [<cite><a class="bibref" href="#bib-rdf11-concepts">RDF11-CONCEPTS</a></cite>] that can be used by subscription clients to discover available features and customize the details (see <a href="#notification-features">Notification Features</a>) of a subscription request.</dd>
 
                     <dt about="#subscription-request" property="skos:prefLabel" typeof="skos:Concept"><dfn id="subscription-request">subscription request</dfn></dt>
-                    <dd about="#subscription-request" property="skos:definition">A <em>subscription request</em> is an HTTP request that targets a <a href="#subscription-resource">subscription resource</a> made by a subscriber indicating interest to receive updates about a particular resource.</dd>
+                    <dd about="#subscription-request" property="skos:definition">A <em>subscription request</em> is an HTTP request that targets a <a href="#subscription-resource">subscription resource</a> made by a subscription client indicating interest to receive updates about a particular resource.</dd>
 
                     <dt about="#subscription-response" property="skos:prefLabel" typeof="skos:Concept"><dfn id="subscription-response">subscription response</dfn></dt>
                     <dd about="#subscription-response" property="skos:definition">A <em>subscription response</em> is an HTTP response to a <a href="#subscription-request">subscription request</a>. The payload of the subscription response are specialised by <a href="#subscription-types">subscription types</a>.</dd>


### PR DESCRIPTION
Depends on #120 

Only uses *subscription client* in two definitions, following the product class naming.