### PR TITLE
Change JSON-LD context URI in Solid Notifications Protocol

### DIFF
--- a/protocol.html
+++ b/protocol.html
@@ -515,7 +515,7 @@ content: "";
               <p>A Resource Server may provide notifications over a notification channel that might be of one of many <a href="#notification-channel-types">notification channel types</a> that build upon existing web protocols.
               Individual <a href="#notification-channel-types">notification channel types</a> may augment the discovery and subscription requirements of the notification protocol.</p>
 
-              <p id="json-ld-format">This specification uses JSON-LD [<cite><a class="bibref" href="#bib-json-ld11">JSON-LD11</a></cite>] as the preferred data format, and <code>https://www.w3.org/ns/solid/notification/v1</code> as a URI for the JSON-LD context and as a value of the <code>profile</code> parameter used for content negotiation.</p>
+              <p id="json-ld-format">This specification uses JSON-LD [<cite><a class="bibref" href="#bib-json-ld11">JSON-LD11</a></cite>] as the preferred data format, and <code>https://www.w3.org/ns/solid/notifications-context/v1</code> as a URI for the JSON-LD context and as a value of the <code>profile</code> parameter used for content negotiation.</p>
 
               <p id="authentication-authorization">This specification does not require a specific authentication and authorization mechanism to be used with the Solid Notification Protocol. Implementations are encouraged to use existing approaches, such as those described in the Solid Protocol sections on <cite><a href="https://solidproject.org/TR/protocol#authentication" rel="cito:discusses">Authentication</a></cite> and <cite><a href="https://solidproject.org/TR/protocol#authorization" rel="cito:discusses">Authorization</a></cite> [<cite><a class="bibref" href="#bib-solid-protocol">SOLID-PROTOCOL</a></cite>].</p>
 
@@ -701,7 +701,7 @@ content: "";
 
                     <pre about="#description-resource-jsonld" datatype="rdf:JSON" property="schema:description"><code>{</code>
 <code>  "@context": [</code>
-<code>    "https://www.w3.org/ns/solid/notification/v1"</code>
+<code>    "https://www.w3.org/ns/solid/notifications-context/v1"</code>
 <code>  ],</code>
 <code>  "id": "https://example.org/guinan/profile",</code>
 <code>  "subscription": [{</code>
@@ -739,7 +739,7 @@ content: "";
 
                     <pre about="#subscription-service-jsonld" datatype="rdf:JSON" property="schema:description"><code>{</code>
 <code>  "@context": [</code>
-<code>    "https://www.w3.org/ns/solid/notification/v1"</code>
+<code>    "https://www.w3.org/ns/solid/notifications-context/v1"</code>
 <code>  ],</code>
 <code>  "id": "https://websocket.example/subscription",</code>
 <code>  "channelType": "WebSocketChannel2023",</code>
@@ -786,7 +786,7 @@ content: "";
 
                     <pre about="#notification-channel-jsonld" datatype="rdf:JSON" property="schema:description"><code>{</code>
 <code>  "@context": [</code>
-<code>    "https://www.w3.org/ns/solid/notification/v1"</code>
+<code>    "https://www.w3.org/ns/solid/notifications-context/v1"</code>
 <code>  ],</code>
 <code>  "id": "https://channel.example/ac748712",</code>
 <code>  "type": "WebSocketChannel2023",</code>
@@ -825,7 +825,7 @@ content: "";
                     <pre about="#notification-update" datatype="rdf:JSON" property="schema:description"><code>{</code>
 <code>  "@context": [</code>
 <code>    "https://www.w3.org/ns/activitystreams",</code>
-<code>    "https://www.w3.org/ns/solid/notification/v1"</code>
+<code>    "https://www.w3.org/ns/solid/notifications-context/v1"</code>
 <code>  ],</code>
 <code>  "id": "urn:uuid:fc8b5af4-bd7e-4fd1-a649-afcbd0e1c083",</code>
 <code>  "type": "Update",</code>
@@ -843,7 +843,7 @@ content: "";
                     <pre about="#notification-add" datatype="rdf:JSON" property="schema:description"><code>{</code>
 <code>  "@context": [</code>
 <code>    "https://www.w3.org/ns/activitystreams",</code>
-<code>    "https://www.w3.org/ns/solid/notification/v1"</code>
+<code>    "https://www.w3.org/ns/solid/notifications-context/v1"</code>
 <code>  ],</code>
 <code>  "id": "urn:uuid:a4da6738-6be0-11ed-90bd-1be4ba6b6b33",</code>
 <code>  "type": "Add",</code>


### PR DESCRIPTION
As per [Solid CG 2023-05-03 meeting](https://github.com/solid/specification/blob/d9c7d62b32aef199b3b84f29840bba93bd6fe5e9/meetings/2023-05-03.md#solid-notifications-vocab-and-json-ld-context) decision with @timbl (as W3C Team contact), we'll need to change the JSON-LD context URL to something like `ns/solid/notifications-context/v1`.

This is a "Corrections that do not add new features" as per https://www.w3.org/2021/Process-20211102/#class-3 , in particular:

>makes conforming data, processors, or other conforming agents become non-conforming according to the new version

This entails that the change here in the Editor's Draft is towards the next release of the Notifications Protocol (0.3.0).

Since the JSON-LD context was never published, I don't suspect any implementation depending on it in the sense that they're fetching it. Besides, the specification only required that implementations recognise the URI, and the reject requests of what's unfamiliar. So, current IP implementations will need to change the URI. I suspect that this won't be a major issue as there will be other changes coming in with 0.3.0.

I suggest that all Notification Channel Types mentioning the JSON-LD context follow this PR.

If anyone has any strong opinions on what the URI should be, **NOW IS THE TIME**.