### PR TITLE
Add notify:filter feature

### DIFF
--- a/protocol.html
+++ b/protocol.html
@@ -655,6 +655,8 @@ content: "";
                         <dd>The proposed or actual starting date and time of a notification channel with value represented in the <code>xsd:dateTime</code> datatype.</dd>
                         <dt id="notify-endAt" rel="dcterms:subject skos:member" resource="http://www.w3.org/ns/solid/notifications#endAt">endAt</dt>
                         <dd>The proposed or actual ending date and time of a notification channel with value represented in the <code>xsd:dateTime</code> datatype.</dd>
+                        <dt id="notify-filter" rel="dcterms:subject skos:member" resource="http://www.w3.org/ns/solid/notifications#filter">filter</dt>
+                        <dd>The proposed characteristics of a notification to be sent to receiver represented as an object.</dd>
                         <dt id="notify-state" rel="dcterms:subject skos:member" resource="http://www.w3.org/ns/solid/notifications#state">state</dt>
                         <dd>The last known state of a topic resource with value represented in the <code>xsd:string</code> datatype.</dd>
                         <dt id="notify-rate" rel="dcterms:subject skos:member" resource="http://www.w3.org/ns/solid/notifications#rate">rate</dt>


### PR DESCRIPTION
Filter feature to refine the characteristics of notifications (towards resolving https://github.com/solid/notifications/issues/159 ).

I suggest that we work on modeling the core filter object (in subsequent PRs), e.g., `type` is a good candidate to filter activity types, and possibly `actor` .. so perhaps the object can be close to an AS2 Object (including Activity), but it should be possible to extend further e.g., Add activities of Annotation objects with a particular license. Makes sense? We can continue in 159.
