### PR TITLE
Remove mention of Solid Process from SotD

### DIFF
--- a/eventsource-channel-2023.html
+++ b/eventsource-channel-2023.html
@@ -268,7 +268,7 @@ content: "";
             <div property="schema:description" datatype="rdf:HTML">
               <p>This section describes the status of this document at the time of its publication.</p>
 
-              <p>This document was published by the <a href="https://www.w3.org/community/solid/">Solid Community Group</a> as an Editor’s Draft. The sections that have been incorporated have been reviewed following the <a href="https://github.com/solid/process">Solid process</a>. However, the information in this document is still subject to change. You are invited to <a href="https://github.com/solid/notifications/issues">contribute</a> any feedback, comments, or questions you might have.</p>
+              <p>This document was published by the <a href="https://www.w3.org/community/solid/">Solid Community Group</a> as an Editor’s Draft. The information in this document is still subject to change. You are invited to <a href="https://github.com/solid/notifications/issues">contribute</a> any feedback, comments, or questions you might have.</p>
 
               <p>Publication as an Editor’s Draft does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr> Membership. This is a draft document and may be updated, replaced or obsoleted by other documents at any time. It is inappropriate to cite this document as other than work in progress.</p>
 

--- a/ldn-channel-2023.html
+++ b/ldn-channel-2023.html
@@ -261,7 +261,7 @@ content: "";
             <div datatype="rdf:HTML" property="schema:description">
               <p>This section describes the status of this document at the time of its publication.</p>
 
-              <p>This document was published by the <a href="https://www.w3.org/groups/cg/solid">Solid Community Group</a> as an <em>Editor’s Draft</em>. The sections that have been incorporated have been reviewed following the <a href="https://github.com/solid/process">Solid process</a>. However, the information in this document is still subject to change. You are invited to <a href="https://github.com/solid/notifications/issues">contribute</a> any feedback, comments, or questions you might have.</p>
+              <p>This document was published by the <a href="https://www.w3.org/groups/cg/solid">Solid Community Group</a> as an <em>Editor’s Draft</em>. The information in this document is still subject to change. You are invited to <a href="https://github.com/solid/notifications/issues">contribute</a> any feedback, comments, or questions you might have.</p>
 
               <p>Publication as an <em>Editor’s Draft</em> does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr> Membership. This is a draft document and may be updated, replaced or obsoleted by other documents at any time. It is inappropriate to cite this document as other than work in progress.</p>
 

--- a/streaming-http-channel-2023.bs
+++ b/streaming-http-channel-2023.bs
@@ -24,8 +24,7 @@ Status Text:
   This section describes the status of this document at the time of its publication.
 
   This document was published by the [Solid Community Group](https://www.w3.org/community/solid/) as
-  an Editor’s Draft. The sections that have been incorporated have been reviewed following the
-  [Solid process](https://github.com/solid/process). However, the information in this document is
+  an Editor’s Draft. The information in this document is
   still subject to change. You are invited to [contribute](https://github.com/solid/solid-oidc/issues)
   any feedback, comments, or questions you might have.
 

--- a/webhook-channel-2023.bs
+++ b/webhook-channel-2023.bs
@@ -25,8 +25,7 @@ Status Text:
   This section describes the status of this document at the time of its publication.
 
   This document was published by the [Solid Community Group](https://www.w3.org/community/solid/) as
-  an Editor’s Draft. The sections that have been incorporated have been reviewed following the
-  [Solid process](https://github.com/solid/process). However, the information in this document is
+  an Editor’s Draft. The information in this document is
   still subject to change. You are invited to [contribute](https://github.com/solid/solid-oidc/issues)
   any feedback, comments, or questions you might have.
 

--- a/webpush-subscription-2022.bs
+++ b/webpush-subscription-2022.bs
@@ -21,8 +21,7 @@ Status Text:
   This section describes the status of this document at the time of its publication.
 
   This document was published by the [Solid Community Group](https://www.w3.org/community/solid/) as
-  an Editor’s Draft. The sections that have been incorporated have been reviewed following the
-  [Solid process](https://github.com/solid/process). However, the information in this document is
+  an Editor’s Draft. The information in this document is
   still subject to change. You are invited to [contribute](https://github.com/solid/solid-oidc/issues)
   any feedback, comments, or questions you might have.
 

--- a/websocket-channel-2023.html
+++ b/websocket-channel-2023.html
@@ -264,7 +264,7 @@ content: "";
             <div property="schema:description" datatype="rdf:HTML">
               <p>This section describes the status of this document at the time of its publication.</p>
 
-              <p>This document was published by the <a href="https://www.w3.org/community/solid/">Solid Community Group</a> as an <em>Editor’s Draft</em>. The sections that have been incorporated have been reviewed following the <a href="https://github.com/solid/process">Solid process</a>. However, the information in this document is still subject to change. You are invited to <a href="https://github.com/solid/notifications/issues">contribute</a> any feedback, comments, or questions you might have.</p>
+              <p>This document was published by the <a href="https://www.w3.org/community/solid/">Solid Community Group</a> as an <em>Editor’s Draft</em>. The information in this document is still subject to change. You are invited to <a href="https://github.com/solid/notifications/issues">contribute</a> any feedback, comments, or questions you might have.</p>
 
               <p>Publication as an <em>Editor’s Draft</em> does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr> Membership. This is a draft document and may be updated, replaced or obsoleted by other documents at any time. It is inappropriate to cite this document as other than work in progress.</p>
 


### PR DESCRIPTION
PR updates the SotD section given that the [Solid CG Charter](https://www.w3.org/community/solid/charter/) supersedes Solid Process.