### PR TITLE
Add HTTP Query Notifications

### DIFF
--- a/shq-notifications-flow-discovery.mmd
+++ b/shq-notifications-flow-discovery.mmd
@@ -1,0 +1,7 @@
+sequenceDiagram
+
+  participant Client
+  participant Server
+
+  Client ->> Server: HEAD Topic Resource
+  Server ->> Client: HTTP Accept-Query: "application/ld+json"#59; <br/>profile="http://www.w3.org/ns/json-ld#35;context<br/>https://www.w3.org/ns/solid/notifications-context/v1"

--- a/shq-notifications-flow-sunscription.mmd
+++ b/shq-notifications-flow-sunscription.mmd
@@ -1,0 +1,7 @@
+sequenceDiagram
+  participant Client
+  participant Server
+
+  Client ->> Server: Subscription Request
+  Server ->> Client: Notification Channel
+  Server -->> Client: Notification Messages

--- a/shq-protocol.html
+++ b/shq-protocol.html
@@ -1,0 +1,1014 @@
+<!DOCTYPE html>
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta charset="utf-8" />
+    <title>Solid HTTP Query Notifications Protocol</title>
+    <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport" />
+<style>
+main,
+main>article,
+main>article>div {
+background:inherit;
+}
+body {
+counter-reset:section sub-section appendix sub-appendix;
+}
+code, samp { color: #e00; }
+pre code, pre samp { color: var(--text); }
+dfn { font-weight:inherit; }
+.do.fragment a { border-bottom:0; }
+.do.fragment a:hover { background:none; border-bottom:0; }
+section figure pre { margin:1em 0; display:block; }
+cite .bibref { font-style: normal; }
+.tabs nav ul li { margin:0; }
+div.issue, div.note, div.warning {
+clear: both;
+margin: 1em 0;
+position: relative;
+}
+div.issue h3, div.note h3,
+div.issue h4, div.note h4,
+div.issue h5, div.note h5 {
+margin:0;
+font-weight:normal;
+font-style:normal;
+font-size:1em;
+}
+div.issue h3 > span, div.note h3 > span,
+div.issue h4 > span, div.note h4 > span,
+div.issue h5 > span, div.note h5 > span,
+figure.example > figcaption > span {
+text-transform: uppercase;
+}
+div.issue h3, div.issue h4, div.issue h5 {
+color:var(--issueheading-text);
+}
+div.note h3, div.note h4, div.note h5 {
+color:var(--noteheading-text);
+}
+figure.example figcaption {
+color:var(--exampleheading-text);
+}
+main figure {
+text-align:left;
+}
+figure[id] {
+position:relative;
+padding:0.5em;
+}
+figure[id] figcaption {
+font-style:normal;
+font-size:1em;
+}
+figure.example figcaption span + span {
+text-transform:initial;
+}
+.copyright + hr {
+border-style: solid;
+}
+header address a[href] {
+float: right;
+margin: 1rem 0 0.2rem 0.4rem;
+background: transparent none repeat scroll 0 0;
+border: medium none;
+text-decoration: none;
+}
+header address img[src*="logos/W3C"] {
+background: #1a5e9a none repeat scroll 0 0;
+border-color: #1a5e9a;
+border-image: none;
+border-radius: 0.4rem;
+border-style: solid;
+border-width: 0.65rem 0.7rem 0.6rem;
+color: white;
+display: block;
+font-weight: bold;
+}
+main article > h1 {
+font-size: 220%;
+font-weight:bold;
+}
+#acknowledgements ul { padding: 0; margin:0; }
+#acknowledgements li { display:inline; }
+#acknowledgements li:after { content: ", "; }
+#acknowledgements li:last-child:after { content: ""; }
+dd .contributed {
+user-select: none;
+}
+aside.do { overflow:inherit; }
+aside.do blockquote {
+padding: 0; border: 0; margin: 0;
+}
+dl[id^="document-"] ul {
+padding-left:0;
+list-style-type:none;
+}
+dl [rel~="odrl:action"],
+dl [rel~="odrl:action"] li {
+display: inline;
+}
+dl [rel~="odrl:action"] li:after {
+content: ", ";
+}
+dl [rel~="odrl:action"] li:last-child:after {
+content: "";
+}
+aside section > .toc,
+aside section > .toc ol {
+margin-left: revert;
+}
+aside section > .toc li li {
+margin-left: 1em;
+font-size: revert;
+}
+table {
+border-collapse:collapse;
+}
+table + table {
+margin-top:2em;
+}
+caption {
+text-align:left;
+padding:0 0.25em 0.25em;
+margin-bottom: 1em;
+font-size: 1em;
+font-style: revert;
+font-weight: bold;
+border-bottom: 1px solid;
+}
+caption, tbody, tfoot {
+border-bottom:2pt solid #ccc;
+}
+thead,
+thead th[colspan] {
+border-bottom:1pt solid #ccc;
+}
+[rowspan] { vertical-align: bottom; }
+tbody [rowspan] { vertical-align: middle; }
+tbody th[scope="rowgroup"] {
+border-bottom:3pt double #ccc;
+}
+tr {
+border-bottom:1pt solid #ccc;
+}
+th, td {
+padding:0.25em;
+font-size:0.923em;
+word-wrap:normal;
+}
+table ul,
+table ol,
+table li,
+table p,
+table dd {
+margin:0;
+text-align:left;
+}
+table ul,
+table ol {
+padding-left:1em;
+}
+tfoot td > * + * {
+margin-top:1em;
+}
+tfoot dd:after { content: "\A"; white-space:pre; }
+tfoot dt, tfoot dd { display:inline; }
+tfoot dd { margin-left: 0.5em; }
+tfoot dd + dt { margin-top:0; }
+article section:not([id=abstract]):not([id=sotd]):not([id=references]):not([id=appendix]):not([id=acknowledgements]):not([id=changelog]):not([id=exit-criteria]) {
+counter-increment:section;
+counter-reset:sub-section;
+}
+article section:not([id=abstract]):not([id=sotd]):not([id=references]):not([id=appendix]):not([id=acknowledgements]):not([id=changelog]) section:not([id$=references]):not([id=exit-criteria]) {
+counter-increment:sub-section;
+counter-reset:sub-sub-section;
+}
+article section:not([id=abstract]):not([id=sotd]):not([id=references]):not([id=appendix]):not([id=acknowledgements]):not([id=changelog]) section:not([id$=references]):not([id=exit-criteria]) section {
+counter-increment:sub-sub-section;
+counter-reset:sub-sub-sub-section;
+}
+article section:not([id=abstract]):not([id=sotd]):not([id=references]):not([id=appendix]):not([id=acknowledgements]):not([id=changelog]) section:not([id$=references]):not([id=exit-criteria]) section section {
+counter-increment:sub-sub-sub-section;
+counter-reset:sub-sub-sub-sub-section;
+}
+article section:not([id=abstract]):not([id=sotd]):not([id=references]):not([id=appendix]):not([id=acknowledgements]):not([id=changelog]):not([id=exit-criteria]):not([id^=table-of-]):not([id^=list-of-]) > h2:before {
+content:counter(section) ".\00a0";
+}
+section:not([id$=references]):not([id^=changelog]):not([id=exit-criteria]):not([id^=table-of-]):not([id^=list-of-]) > h3:before {
+content:counter(section) "." counter(sub-section) "\00a0";
+}
+section > h4:before {
+content:counter(section)"." counter(sub-section) "." counter(sub-sub-section) "\00a0";
+}
+article section.appendix {
+counter-increment:appendix;
+counter-reset:sub-appendix;
+}
+article section[class~=appendix]:not([id=abstract]):not([id=sotd]):not([id=appendix]):not([id=acknowledgements]):not([id=changelog]):not([id=exit-criteria]) section {
+counter-increment:sub-appendix;
+counter-reset:sub-sub-appendix;
+}
+section.appendix > h2:before {
+content:counter(appendix, upper-alpha) ".\00a0";
+}
+section.appendix section > h3:before {
+content:counter(appendix, upper-alpha) "." counter(sub-appendix) "\00a0";
+}
+</style>
+    <link href="https://www.w3.org/StyleSheets/TR/2021/base.css" media="all" rel="stylesheet" title="W3C-Base" />
+    <link href="https://www.w3.org/StyleSheets/TR/2021/dark.css" media="(prefers-color-scheme: dark)" rel="stylesheet" />
+    <link href="https://dokie.li/media/css/dokieli.css" media="all" rel="stylesheet" />
+    <script async="" src="https://dokie.li/scripts/dokieli.js"></script>
+  </head>
+
+  <body about="" prefix="rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns# rdfs: http://www.w3.org/2000/01/rdf-schema# owl: http://www.w3.org/2002/07/owl# xsd: http://www.w3.org/2001/XMLSchema# dcterms: http://purl.org/dc/terms/ skos: http://www.w3.org/2004/02/skos/core# prov: http://www.w3.org/ns/prov# mem: http://mementoweb.org/ns# qb: http://purl.org/linked-data/cube# schema: http://schema.org/ doap: http://usefulinc.com/ns/doap# deo: http://purl.org/spar/deo/ cito: http://purl.org/spar/cito/ as: https://www.w3.org/ns/activitystreams# ldp: http://www.w3.org/ns/ldp# earl: http://www.w3.org/ns/earl# spec: http://www.w3.org/ns/spec# rel: https://www.w3.org/ns/iana/link-relations/relation# odrl: http://www.w3.org/ns/odrl/2/">
+    <main>
+      <article about="" typeof="schema:Article">
+        <div class="head">
+          <h1 property="schema:name">Solid HTTP Query Notifications Protocol</h1>
+
+          <p id="w3c-state">Unofficial Draft, <time datetime="2025-04-11T00:00:00Z">2025-04-11</time></p>
+
+          <details open="">
+            <summary>More details about this document</summary>
+
+            <dl id="document-identifier">
+              <dt>This version</dt>
+              <dd><a href="https://solid.github.io/notifications/shq-protocol" rel="owl:sameAs">https://solid.github.io/notifications/shq-protocol</a></dd>
+            </dl>
+
+            <!-- <dl id="document-latest-published-version">
+              <dt>Latest published version</dt>
+              <dd><a href="https://solidproject.org/TR/shq-notifications-protocol" rel="rel:latest-version">https://solidproject.org/TR/shq-notifications-protocol</a></dd>
+            </dl> -->
+
+            <dl id="document-history">
+              <dt>History</dt>
+              <dd><a href="https://github.com/solid/notifications/commits/main/shq-protocol.html">Commit history</a></dd>
+            </dl>
+
+            <dl id="document-editors">
+              <dt>Editors</dt>
+              <dd data-editor-id="" id="Rahul Gupta"><span about="" rel="schema:creator schema:editor"><span about="https://cxres.pages.dev/profile#i" typeof="schema:Person"><a href="https://cxres.pages.dev/" rel="schema:url"><span about="https://cxres.pages.dev/profile#i" property="schema:name"><span property="schema:givenName">Rahul</span> <span property="schema:familyName">Gupta</span></span></a></span></span></dd>
+            </dl>
+
+            <dl id="document-authors">
+              <dt>Authors</dt>
+              <dd id="Rahul-Gupta"><span about="" rel="schema:author"><span about="https://cxres.pages.dev/profile#i" typeof="schema:Person"><a href="https://cxres.pages.dev/" rel="schema:url"><span about="https://cxres.pages.dev/profile#i" property="schema:name"><span property="schema:givenName">Rahul</span> <span property="schema:familyName">Gupta</span></span></a></span></span></dd>
+            </dl>
+
+            <dl id="document-created">
+              <dt>Created</dt>
+              <dd><time content="2025-04-11T00:00:00Z" datatype="xsd:dateTime" datetime="2025-04-11T00:00:00Z" property="schema:dateCreated">2025-04-11</time></dd>
+            </dl>
+
+            <dl id="document-published">
+              <dt>Published</dt>
+              <dd><time content="2025-04-11T00:00:00Z" datatype="xsd:dateTime" datetime="2025-04-11T00:00:00Z" property="schema:datePublished">2025-04-11</time></dd>
+            </dl>
+
+            <dl id="document-modified">
+              <dt>Modified</dt>
+              <dd><time content="2024-04-11T00:00:00Z" datatype="xsd:dateTime" datetime="2024-04-11T00:00:00Z" property="schema:dateModified">2025-04-11</time></dd>
+            </dl>
+
+            <dl id="document-feedback">
+              <dt>Feedback</dt>
+              <dd><a href="https://github.com/solid/notifications" rel="doap:repository">GitHub solid/notifications</a> (<a href="https://github.com/solid/notifications/pulls">pull requests</a>, <a href="https://github.com/solid/notifications/issues/new">new issue</a>, <a href="https://github.com/solid/notifications/issues" rel="doap:bug-database">open issues</a>)</dd>
+            </dl>
+
+            <dl id="document-language">
+              <dt>Language</dt>
+              <dd><span content="en" lang="" property="dcterms:language" xml:lang="">English</span></dd>
+            </dl>
+
+            <dl id="document-type">
+              <dt>Document Type</dt>
+              <dd><a href="http://usefulinc.com/ns/doap#Specification" rel="rdf:type">Specification</a></dd>
+            </dl>
+
+            <dl id="document-version">
+              <dt>Version</dt>
+              <dd><span lang="" property="schema:version" xml:lang="">0.1.0</span></dd>
+            </dl>
+
+            <dl id="document-in-reply-to">
+              <dt>In Reply To</dt>
+              <dd><a href="https://solidproject.org/about" rel="as:inReplyTo">About Solid</a></dd>
+              <dd><a href="https://github.com/solid/process/blob/main/notifications-panel-charter.md" rel="as:inReplyTo">Notifications Panel Charter</a></dd>
+            </dl>
+
+            <dl id="document-policy">
+              <dt>Policy</dt>
+              <dd>
+                <dl id="document-policy-offer" rel="odrl:hasPolicy" resource="#document-policy-offer" typeof="odrl:Policy">
+                  <dt>Rule</dt>
+                  <dd><a about="#document-policy-offer" href="https://www.w3.org/TR/odrl-vocab/#term-Offer" typeof="odrl:Offer">Offer</a></dd>
+                  <dt>Unique Identifier</dt>
+                  <dd><a href="https://solid.github.io/notifications/http-query#document-policy-offer" rel="odrl:uid">https://solid.github.io/notifications/http-query#document-policy-offer</a></dd>
+                  <dt>Target</dt>
+                  <dd><a href="https://solid.github.io/notifications/shq-protocol" rel="odrl:target">https://solid.github.io/notifications/shq-protocol</a></dd>
+                  <dt>Permission</dt>
+                  <dd>
+                    <dl id="document-permission" rel="odrl:permission" resource="#document-permission" typeof="odrl:Permission">
+                      <dt>Assigner</dt>
+                      <dd><a href="https://www.w3.org/groups/cg/solid/" rel="odrl:assigner">W3C Solid Community Group</a></dd>
+                      <dt>Action</dt>
+                      <dd>
+                        <ul rel="odrl:action">
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-aggregate" resource="odrl:aggregate">Aggregate</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-archive" resource="odrl:archive">Archive</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-concurrentUse" resource="odrl:concurrentUse">Concurrent Use</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-DerivativeWorks" resource="http://creativecommons.org/ns#DerivativeWorks">Derivative Works</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-derive" resource="odrl:derive">Derive</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-digitize" resource="odrl:digitize">Digitize</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-display" resource="odrl:display">Display</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-Distribution" resource="http://creativecommons.org/ns#Distribution">Distribution</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-index" resource="odrl:index">Index</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-inform" resource="odrl:inform">Inform</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-install" resource="odrl:install">Install</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-Notice" resource="http://creativecommons.org/ns#Notice">Notice</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-present" resource="odrl:present">Present</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-print" resource="odrl:print">Print</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-read" resource="odrl:read">Read</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-reproduce" resource="odrl:reproduce">Reproduce</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-Reproduction" resource="http://creativecommons.org/ns#Reproduction">Reproduction</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-stream" resource="odrl:stream">Stream</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-synchronize" resource="odrl:synchronize">Synchronize</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-textToSpeech" resource="odrl:textToSpeech">Text-to-speech</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-transform" resource="odrl:transform">Transform</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-translate" resource="odrl:translate">Translate</a></li>
+                        </ul>
+                      </dd>
+                    </dl>
+                  </dd>
+                </dl>
+              </dd>
+            </dl>
+          </details>
+
+          <p class="copyright" rel="dcterms:rights" resource="#document-rights"><span property="dcterms:description"><a href="https://www.w3.org/policies/#copyright">Copyright</a> © 2025 the Contributors to Solid HTTP Query Notifications Protocol, Unofficial Draft. All code snippets are in the public domain, <a about="" href="https://creativecommons.org/public-domain/cc0/" rel="schema:license">CC0</a>.</span></p>
+
+          <hr title="Separator for header" />
+        </div>
+
+        <div datatype="rdf:HTML" id="content" property="schema:description">
+          <section id="abstract">
+            <h2>Abstract</h2>
+            <div datatype="rdf:HTML" property="schema:abstract">
+              <p>This specification extends the Solid Notification Protocol to provide a faster mechanism for receiving streaming HTTP notifications from Solid resources.</p>
+            </div>
+          </section>
+
+          <section id="sotd" inlist="" rel="schema:hasPart" resource="#sotd">
+            <h2 property="schema:name">Status of This Document</h2>
+            <div datatype="rdf:HTML" property="schema:description">
+              <p>This report was not published by the <a href="https://www.w3.org/groups/cg/solid/">Solid Community Group</a>. It is not a W3C Standard nor is it on the W3C Standards Track.</p>
+
+              <p>Publication as an Unofficial Draft implies that it is not endorsed by anyone. This document and may be updated, replaced or obsoleted by other documents at any time. It is inappropriate to cite this document as other than work in progress. You are invited to contribute any feedback, comments, or questions you might have.</p>
+            </div>
+          </section>
+
+          <nav id="toc">
+            <h2>Table of Contents</h2>
+            <div>
+              <ol class="toc">
+                <li class="tocline">
+                  <a class="tocxref" href="#abstract">Abstract</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#sotd">Status of This Document</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#introduction"><bdi class="secno">1.</bdi> <span>Introduction</span></a>
+                  <ol>
+                    <li class="tocline"><a class="tocxref" href="#overview"><bdi class="secno">1.1</bdi> <span>Overview</span></a></li>
+                    <li class="tocline"><a class="tocxref" href="#namespaces"><bdi class="secno">1.2</bdi> <span>Namespaces</span></a></li>
+                    <li class="tocline"><a class="tocxref" href="#conformance"><bdi class="secno">1.3</bdi> <span>Conformance</span></a></li>
+                  </ol>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#protocol"><bdi class="secno">2.</bdi> <span>Protocol</span></a>
+                  <ol>
+                    <li class="tocline">
+                      <a class="tocxref" href="#discovery"><bdi class="secno">2.1</bdi> <span>Discovery</span></a>
+                    </li>
+                    <li class="tocline">
+                      <a class="tocxref" href="#subscription"><bdi class="secno">2.2</bdi> <span>Subscription</span></a>
+                    </li>
+                    <li class="tocline">
+                      <a class="tocxref" href="#notifications"><bdi class="secno">2.3</bdi> <span>Notifications</span></a>
+                    </li>
+                    <li class="tocline">
+                      <a class="tocxref" href="#notification-message"><bdi class="secno">2.4</bdi> <span>Notification Message</span></a>
+                    </li>
+                  </ol>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#data-model"><bdi class="secno">3.</bdi> <span>Data Model</span></a>
+                  <ol>
+                    <li class="tocline">
+                      <a class="tocxref" href="#description-resource-data-model"><bdi class="secno">3.1</bdi> <span>Description Resource</span></a>
+                    </li>
+                    <li class="tocline">
+                      <a class="tocxref" href="#subscription-service-data-model"><bdi class="secno">3.2</bdi> <span>Subscription Service</span></a>
+                    </li>
+                    <li class="tocline">
+                      <a class="tocxref" href="#notification-channel-data-model"><bdi class="secno">3.3</bdi> <span>Notification Channel</span></a>
+                    </li>
+                    <li class="tocline">
+                      <a class="tocxref" href="#notification-message-data-model"><bdi class="secno">3.4</bdi> <span>Notification Message</span></a>
+                    </li>
+                  </ol>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#considerations"><bdi class="secno">4.</bdi> <span>Considerations</span></a>
+                  <ol>
+                    <li><a href="#security-considerations"><bdi class="secno">4.1</bdi> <span>Security Considerations</span></a></li>
+                    <li><a href="#privacy-considerations"><bdi class="secno">4.2</bdi> <span>Privacy Considerations</span></a></li>
+                    <li><a href="#security-privacy-review"><bdi class="secno">4.3</bdi> <span>Security and Privacy Review</span></a></li>
+                  </ol>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#changelog"><bdi class="secno">A.</bdi> <span>Changelog</span></a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#acknowledgements"><bdi class="secno">B.</bdi> <span>Acknowledgements</span></a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#references"><bdi class="secno">C.</bdi> <span>References</span></a>
+                  <ol>
+                    <li class="tocline"><a class="tocxref" href="#normative-references"><bdi class="secno">C.1</bdi> <span>Normative References</span></a></li>
+                    <li class="tocline"><a class="tocxref" href="#informative-references"><bdi class="secno">C.2</bdi> <span>Informative References</span></a></li>
+                  </ol>
+                </li>
+              </ol>
+            </div>
+          </nav>
+
+          <section id="introduction" inlist="" rel="schema:hasPart" resource="#introduction">
+            <h2 about="#introduction" property="schema:name" typeof="deo:Introduction">Introduction</h2>
+            <div datatype="rdf:HTML" property="schema:description">
+              <p><em>This section is non-normative.</em></p>
+
+              <p>The <cite><a href="https://solidproject.org/TR/notifications-protocol" rel="cito:discusses">Solid Notifications Protocol</a></cite> [<cite><a class="bibref" href="#bib-solid-notifications-protocol" >SOLID-NOTIFICATIONS-PROTOCOL</a></cite>] defines an extensible, HTTP-based framework by which client applications can receive notifications for HTTP resource changes.</p>
+
+              <p id="motivation" rel="schema:hasPart" resource="#motivation" typeof="deo:Motivation"><span datatype="rdf:HTML" property="schema:description">The Solid HTTP Query (SHQ) Notifications Protocol specifies a faster mechanism for receiving <cite><a href="https://solid.github.io/notifications/streaming-http-channel-2023" rel="cito:discusses">streaming HTTP</a></cite> [<cite><a class="bibref" href="#bib-solid-streaming-http-channel-2023">SOLID-STREAMINGHTTPCHANNEL2023</a></cite>] notifications that conform to the <cite><a href="https://solidproject.org/TR/notifications-protocol" rel="cito:discusses">Solid Notifications Protocol</a></cite> by combining the subscription for and the receipt of notifications into a single HTTP request/response round-trip.</span></p>
+
+              <p>This specification is for:</p>
+
+              <ul about="" rel="schema:audience">
+                <li><a href="http://data.europa.eu/esco/occupation/a7c1d23d-aeca-4bee-9a08-5993ed98b135">Server developers</a> that want to enable clients to listen for updates to particular resources.</li>
+                <li><a href="http://data.europa.eu/esco/occupation/c40a2919-48a9-40ea-b506-1f34f693496d">Application developers</a> who want to implement a client to listen for updates to particular resources.</li>
+              </ul>
+
+              <p>In addition to this specification, readers might find the Use Cases and Requirements for Notifications Protocol [<cite><a class="bibref" href="#bib-notifications-ucr">NOTIFICATIONS-UCR</a></cite>] document useful.</p>
+
+              <section id="overview" inlist="" rel="schema:hasPart" resource="#overview">
+                <h3 property="schema:name">Overview</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p><em>This section is non-normative.</em></p>
+
+                  <p>The Solid HTTP Query Notification protocol allows client applications to discover notification services available for any given resource.</p>
+
+                  <p>The following diagram shows the high-level interactions involved in the discovery of HTTP Query Notifications.</p>
+
+                  <figure id="shq-notifications-flow-discovery" rel="schema:hasPart" resource="#shq-notifications-flow-discovery-subscription">
+                    <figcaption property="schema:name">Solid HTTP Query Notifications Discovery</figcaption>
+
+                    <img rel="schema:image" src="shq-notifications-flow-discovery.mmd.svg" width="800" />
+                  </figure>
+
+                  <p>Client applications can use the usual <cite><a href="https://solidproject.org/TR/notifications-protocol#solid-notifications-flow-discovery" rel="cito:discusses">discovery flow</a></cite> [<cite><a class="bibref" href="#bib-solid-notifications-protocol" >SOLID-NOTIFICATIONS-PROTOCOL</a></cite>] to learn more about the available subscription mechanism.</p>
+
+                  <p>Clients make a <code>QUERY</code> [<cite><a class="bibref" href="#bib-http-query">HTTP-QUERY</a></cite>] request to the resource to start receiving notifications.</p>
+
+                  <p>The following diagram shows the high-level interactions involved in subscribing for and receiving <cite><a href="https://solid.github.io/notifications/streaming-http-channel-2023" rel="cito:discusses">streaming HTTP</a></cite> [<cite><a class="bibref" href="#bib-solid-streaming-http-channel-2023">SOLID-STREAMINGHTTPCHANNEL2023</a></cite>] notifications:</p>
+
+                  <figure id="shq-notifications-flow-subscription" rel="schema:hasPart" resource="#shq-notifications-flow-subscription">
+                    <figcaption property="schema:name">Solid HTTP Query Notifications Subscription</figcaption>
+
+                    <img rel="schema:image" src="shq-notifications-flow-subscription.mmd.svg" width="800" />
+                  </figure>
+                </div>
+              </section>
+
+              <section id="namespaces" inlist="" rel="schema:hasPart" resource="#namespaces" typeof="skos:Collection">
+                <h3 property="schema:name skos:prefLabel">Namespaces</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <table>
+                    <caption>Prefixes and Namespaces</caption>
+                    <thead>
+                      <tr>
+                        <th>Prefix</th>
+                        <th>Namespace</th>
+                        <th>Description</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr rel="skos:member" resource="http://www.w3.org/ns/solid/notifications#" typeof="owl:Ontology">
+                        <td><code>notify</code></td>
+                        <td>http://www.w3.org/ns/solid/notifications#</td>
+                        <td property="skos:prefLabel">Solid Notifications</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </section>
+
+              <section id="conformance" inlist="" rel="schema:hasPart" resource="#conformance">
+                <h3 property="schema:name">Conformance</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p>This section describes the <span about="" rel="spec:conformance" resource="#conformance">conformance model of the Solid HTTP Query Notifications Protocol</span>.</p>
+
+                  <section id="normative-informative-content" inlist="" rel="schema:hasPart" resource="#normative-informative-content">
+                    <h4 property="schema:name">Normative and Informative Content</h4>
+                    <div datatype="rdf:HTML" property="schema:description">
+                      <p id="normative-informative-sections">All assertions, diagrams, examples, and notes are non-normative, as are all sections explicitly marked non-normative. Everything else is normative.</p>
+
+                      <p id="requirement-levels">The key words “<span rel="dcterms:subject" resource="spec:MUST">MUST</span>”, “<span rel="dcterms:subject" resource="spec:MUSTNOT">MUST NOT</span>”, “<span rel="dcterms:subject" resource="spec:SHOULD">SHOULD</span>”, and “<span rel="dcterms:subject" resource="spec:MAY">MAY</span>” are to be interpreted as described in <a href="https://www.rfc-editor.org/info/bcp14">BCP 14</a> [<cite><a class="bibref" href="#bib-rfc2119">RFC2119</a></cite>] [<cite><a class="bibref" href="#bib-rfc8174">RFC8174</a></cite>] when, and only when, they appear in all capitals, as shown here.</p>
+
+                      <p id="advisement-levels">The key words “<span rel="dcterms:subject" resource="spec:StronglyEncouraged">strongly encouraged</span>”, “<span rel="dcterms:subject" resource="spec:StronglyDiscouraged">strongly discouraged</span>”, “<span rel="dcterms:subject" resource="spec:Encouraged">encouraged</span>", “<span rel="dcterms:subject" resource="spec:Discouraged">discouraged</span>", “<span rel="dcterms:subject" resource="spec:Can">can</span>", “<span rel="dcterms:subject" resource="spec:Cannot">cannot</span>”, “<span rel="dcterms:subject" resource="spec:Could">could</span>”, “<span rel="dcterms:subject" resource="spec:CouldNot">could not</span>”, “<span rel="dcterms:subject" resource="spec:Might">might</span>”, and “<span rel="dcterms:subject" resource="spec:MightNot">might not</span>” are used for non-normative content.</p>
+                    </div>
+                  </section>
+
+                  <section id="specification-category" inlist="" rel="schema:hasPart" resource="#specification-category" typeof="skos:ConceptScheme">
+                    <h4 property="schema:name skos:prefLabel">Specification Category</h4>
+                    <div datatype="rdf:HTML" property="schema:description">
+                      <p property="skos:definition">The <span about="" rel="spec:specificationCategory" resource="#specification-category">Solid HTTP Query Notifications Protocol</span> identifies the following <cite><a href="https://www.w3.org/TR/spec-variability/#spec-cat" rel="dcterms:subject" resource="spec:SpecificationCategory">Specification Category</a></cite> to distinguish the types of conformance: <span rel="skos:hasTopConcept" resource="spec:API">API</span>, <span rel="skos:hasTopConcept" resource="spec:NotationSyntax">notation/syntax</span>, <span rel="skos:hasTopConcept" resource="spec:SetOfEvents">set of events</span>, <span rel="skos:hasTopConcept" resource="spec:Protocol">protocol</span>.</p>
+                    </div>
+                  </section>
+
+                  <section id="classes-of-products" inlist="" rel="schema:hasPart" resource="#classes-of-products" typeof="skos:ConceptScheme">
+                    <h4 property="schema:name skos:prefLabel">Classes of Products</h4>
+                    <div datatype="rdf:HTML" property="schema:description">
+                      <p property="skos:definition">The <span about="" rel="spec:classesOfProducts" resource="#classes-of-products">Solid HTTP Query Notifications Protocol</span> identifies the following <cite><a href="https://www.w3.org/TR/qaframe-spec/#cop-def" rel="dcterms:subject" resource="spec:ClassesOfProducts">Classes of Products</a></cite> for conforming implementations. These products are referenced throughout this specification.</p>
+
+                      <dl rel="skos:hasTopConcept">
+                        <dt about="#Server" property="skos:prefLabel" rel="skos:broadMatch" resource="spec:RespondingAgent" typeof="skos:Concept"><dfn id="Server">Server</dfn></dt>
+                        <dd about="#Server" property="skos:definition">A <em>Server</em> builds on an HTTP <cite>server</cite> [<cite><a class="bibref" href="#bib-rfc9110">RFC9110</a></cite>] and [<cite><a class="bibref" href="#bib-rfc9112">RFC9112</a></cite>] by defining media types, HTTP header fields, and the behaviour of resources, as identified by link relations. The <em>Server</em> combines the roles of <cite><a href="https://solidproject.org/TR/notifications-protocol#ResourceServer" rel="cito:discusses">Resource Server</a></cite>, <cite><a href="https://solidproject.org/TR/notifications-protocol#SubscriptionServer" rel="cito:discusses">Subscription Server</a></cite> and <cite><a href="https://solidproject.org/TR/notifications-protocol#NotificationSender" rel="cito:discusses">Notification Sender</a></cite> defined in the <cite><a href="https://solidproject.org/TR/notifications-protocol" rel="cito:discusses">Solid Notifications Protocol</a></cite> [<cite><a class="bibref" href="#bib-solid-notifications-protocol" >SOLID-NOTIFICATIONS-PROTOCOL</a></cite>].</dd>
+                        <dt about="#Client" property="skos:prefLabel" rel="skos:broadMatch" resource="spec:Consumer" typeof="skos:Concept"><dfn id="Client">Client</dfn></dt>
+                        <dd about="#Client" property="skos:definition">A <em> Client</em> that builds on HTTP <cite>client</cite> [<cite><a class="bibref" href="#bib-rfc9110">RFC9110</a></cite>], [<cite><a class="bibref" href="#bib-rfc9112">RFC9112</a></cite>], and [<cite><a class="bibref" href="#bib-fetch">FETCH</a></cite>] by defining behaviour in terms of fetching across the platform. The <em>Client</em> combines the roles of <cite><a href="https://solidproject.org/TR/notifications-protocol#DiscoveryClient" rel="cito:discusses">Discovery Client</a></cite>, <cite><a href="https://solidproject.org/TR/notifications-protocol#SubscriptionClient" rel="cito:discusses">Subscription Client</a></cite> and <cite><a href="https://solidproject.org/TR/notifications-protocol#NotificationReceiver" rel="cito:discusses">Notification Receiver</a></cite> defined in the <cite><a href="https://solidproject.org/TR/notifications-protocol" rel="cito:discusses">Solid Notifications Protocol</a></cite> [<cite><a class="bibref" href="#bib-solid-notifications-protocol" >SOLID-NOTIFICATIONS-PROTOCOL</a></cite>].</dd>
+                       </dl>
+                    </div>
+                  </section>
+
+                  <section id="interoperability" inlist="" rel="schema:hasPart" resource="#interoperability" typeof="skos:ConceptScheme">
+                    <h4 property="schema:name skos:prefLabel">Interoperability</h4>
+                    <div datatype="rdf:HTML" property="schema:description">
+                      <p property="skos:definition">Interoperability occurs between <a href="#client-server-interoperability" rel="skos:hasTopConcept"> Client–Server</a>.</p>
+
+                      <dl>
+                        <dt about="#client-server-interoperability" property="skos:prefLabel" typeof="skos:Concept"><dfn id="client-server-interoperability">Client–Server interoperability</dfn></dt>
+                        <dd about="#client-server-interoperability" property="skos:definition">Interoperability of implementations for <a href="#Client" rel="rdfs:seeAlso">Client</a> and <a href="#Server" rel="rdfs:seeAlso">Servers</a> is tested by evaluating an implementation’s ability to request and respond to HTTP messages that conform to the Solid HTTP Query Notifications Protocol.</dd>
+                      </dl>
+                    </div>
+                  </section>
+                </div>
+              </section>
+            </div>
+          </section>
+
+          <section id="protocol" inlist="" rel="schema:hasPart" resource="#protocol">
+            <h2 property="schema:name">Protocol</h2>
+            <div datatype="rdf:HTML" property="schema:description">
+              <p>The <cite><a href="https://solidproject.org/TR/notifications-protocol" rel="cito:discusses">Solid Notifications Protocol</a></cite> [<cite><a class="bibref" href="#bib-solid-notifications-protocol" >SOLID-NOTIFICATIONS-PROTOCOL</a></cite>] specifies a Linked Data-based protocol for sending notifications to client applications upon updates to resources in the Solid ecosystem while respecting resource-based access controls and privacy.</p>
+
+              <p>Solid HTTP Query (SHQ) Notifications Protocol extends the <cite><a href="https://solidproject.org/TR/notifications-protocol" rel="cito:discusses">Solid Notifications Protocol</a></cite> specifically for <a href="https://solid.github.io/notifications/streaming-http-channel-2023" rel="cito:discusses">streaming HTTP</a> [<cite><a class="bibref" href="#bib-solid-streaming-http-channel-2023">SOLID-STREAMINGHTTPCHANNEL2023</a></cite>] notifications using the <code>QUERY</code> [<cite><a class="bibref" href="#bib-http-query">HTTP-QUERY</a></cite>] method:</p>
+
+              <ul>
+                <li>to allow subscriptions to be established from any Solid resource, and</li>
+                <li>to combine the subscription for and the receipt of notifications into a single HTTP request/response round-trip.</li>
+              </ul>
+
+              <p id="json-ld-format">This specification uses JSON-LD [<cite><a class="bibref" href="#bib-json-ld11">JSON-LD11</a></cite>] as the preferred data format, and <code>https://www.w3.org/ns/solid/notifications-context/v1</code> as a URI for the JSON-LD context and as a value of the <code>profile</code> parameter used for content negotiation.</p>
+
+              <p id="authentication-authorization">This specification does not require a specific authentication and authorization mechanism to be used. Implementations are encouraged to use existing approaches, such as those described in the <cite><a rel="cito:discusses" href="#bib-solid-protocol">Solid Protocol</a></cite> sections on <cite><a href="https://solidproject.org/TR/protocol#authentication" rel="cito:discusses">Authentication</a></cite> and <cite><a href="https://solidproject.org/TR/protocol#authorization" rel="cito:discusses">Authorization</a></cite> [<cite><a class="bibref" href="#bib-solid-protocol">SOLID-PROTOCOL</a></cite>].</p>
+
+              <section id="discovery" inlist="" rel="schema:hasPart" resource="#discovery">
+                <h3 property="schema:name">Discovery</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+
+                  A <a href="#Server">Server</a> advertises the capability of a resource to provide SHQ notification using the <code>Accept-Query</code> header field. Further, the <a href="#Client">Client</a> can discover further information about SHQ notifications available on the resource by accessing the <cite><a href="https://solidproject.org/TR/notifications-protocol#description-resource" rel="cito:discusses">description resource</a></cite> [<cite><a class="bibref" href="#bib-solid-notifications-protocol" >SOLID-NOTIFICATIONS-PROTOCOL</a></cite>]</a>.</p>
+
+                  <p>When a resource supports SHQ notifications:</p>
+
+                  <ul>
+
+                    <li>A <a href="#Server">Server</a> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> set the <code>Accept-Query</code> header field to <code>"application/ld+json"; profile="http://www.w3.org/ns/json-ld#context https://www.w3.org/ns/solid/notifications-context/v1"</code> on any resource that supports notifications.</li>
+
+                    <li about="" id="server-notification-capability-description-resource" rel="spec:requirement" resource="#server-link-storage-description-resource"><span property="spec:statement">A <a href="#Server" rel="spec:requirementSubject">Server</a>  <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> advertise the capability to subscribe to notifications using the <code>QUERY</code> [<cite><a class="bibref" href="#bib-http-query">HTTP-QUERY</a></cite>] method on the corresponding <cite><a href="https://solidproject.org/TR/notifications-protocol#description-resource" rel="cito:discusses">description resource</a></cite>.</span></li>
+
+                    <li about="" id="resource-server-description-resource-response" rel="spec:requirement" resource="#resource-server-description-resource-response"><span property="spec:statement">A <a href="#Server" rel="spec:requirementSubject">Server</a> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> use the <a href="#description-resource-data-model" rel="rdfs:seeAlso">Description Resource Data Model</a> in the corresponding <cite><a href="https://solidproject.org/TR/notifications-protocol#description-resource" rel="cito:discusses">description resource</a></cite> response content.</span></li>
+                  </ul>
+                </div>
+              </section>
+
+              <section id="subscription" inlist="" rel="schema:hasPart" resource="#subscription">
+                <h3 property="schema:name">Subscription</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+
+                  <p about="#subscription-request" property="skos:definition" typeof="skos:Concept"> A <a href="#Client" rel="spec:requirementSubject">Client</a> subscribes to SHQ notifications by making a <code>QUERY</code> request to a resource.
+                  The content of the subscription request describes the desired <cite><a href="https://solidproject.org/TR/notifications/streaming-http-channel-2023" rel="cito:discusses">streaming HTTP</a></cite> [<cite><a class="bibref" href="#bib-solid-streaming-http-channel-2023">SOLID-STREAMINGHTTPCHANNEL2023</a></cite>] <cite><a href="https://solidproject.org/TR/notifications-protocol#notification-channel" rel="cito:discusses">notification channel</a></cite> [<cite><a class="bibref" href="#bib-solid-notifications-protocol" >SOLID-NOTIFICATIONS-PROTOCOL</a></cite>].</p>
+
+                  <p>To subscribe to SHQ notifications from a resource:</p>
+                  <ul>
+                    <li about="" id="client-subscription-request" rel="spec:requirement" resource="#client-subscription-request"><span property="spec:statement">A <a href="#Client" rel="spec:requirementSubject">Client</a> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> send a <code>QUERY</code> request using the <a href="#notification-channel-data-model" rel="rdfs:seeAlso">Notification Channel Data Model</a> in the request content.</span></li>
+                  </ul>
+
+                  <p>When a resource supports SHQ notifications:</p>
+
+                  <ul>
+                    <li about="" id="server-subscription-request-methods" rel="spec:requirement" resource="#server-subscription-request-methods"><span property="spec:statement">A <a href="#Server" rel="spec:requirementSubject">Server</a> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> allow the <code>OPTIONS</code> [<cite><a class="bibref" href="#bib-rfc9110">RFC9110</a></cite>] and <code>QUERY</code> [<cite><a class="bibref" href="#bib-http-query">HTTP-QUERY</a></cite>] methods on the resource.</span></li>
+
+                    <!--<li about="" id="Server-subscription-resource-accept" rel="spec:requirement" resource="#server-subscription-resource-accept"><span property="spec:statement">A <a href="#Server" rel="spec:requirementSubject">Server</a> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> accept <code>QUERY</code> requests targeting the resource when the <code>Accept</code> header field indicates a preferred representation of <code>application/ld+json</code> [<cite><a class="bibref" href="#bib-json-ld11">JSON-LD11</a></cite>].</span></li> -->
+
+                    <li about="" id="server-subscription-request-content-type" rel="spec:requirement" resource="#server-subscription-request-content-type"><span property="spec:statement">A <a href="#Server" rel="spec:requirementSubject">Server</a> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> accept <code>QUERY</code> requests targeting the resource with the <code>Content-Type</code> header field set to <code>application/ld+json</code> [<cite><a class="bibref" href="#bib-json-ld11">JSON-LD11</a></cite>].</span></li>
+
+
+                  </ul>
+
+                  <figure class="example listing" id="subscription-request-example" rel="schema:hasPart" resource="#subscription-request-example">
+                    <figcaption property="schema:name"><span>Example</span>: <span>Subscription request.</span></figcaption>
+                    <pre property="schema:description">
+<code>QUERY /guinan/profile HTTP/1.1</code>
+<code>Host: example.org</code>
+<code>Accept: application/ld+json</code>
+<code>Content-Type: application/ld+json</code>
+<code></code>
+<code>{</code>
+<code>  "@context": [</code>
+<code>    "https://www.w3.org/ns/solid/notifications-context/v1"</code>
+<code>  ],</code>
+<code>  "topic": [</code>
+<code>    "https://example.org/guinan/profile",</code>
+<code>  ],</code>
+<code>}</code></pre></figure>
+
+
+                <p>When the subscription request is not successful:</p>
+
+                <ul>
+                  <li about="" id="server-subscription-request-profile-unrecognised" rel="spec:requirement" resource="#server-subscription-request-profile-unrecognised"><span property="spec:statement">A <a href="#Server" rel="spec:requirementSubject">Server</a> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> respond with a <code>415</code> status code for <code>QUERY</code> requests with unsupported values in the <code>profile</code> parameter for the <code>application/ld+json</code> media type.</span></li>
+
+                  <li about="" id="server-subscription-request-unprocessable-entity" rel="spec:requirement" resource="#server-subscription-request-unprocessable-entity"><span property="spec:statement">A <a href="#Server" rel="spec:requirementSubject">Server</a> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> respond with a <code>422</code> status code [<cite><a class="bibref" href="#bib-rfc4918">RFC4918</a></cite>] if it is unable to process the contained instructions, including unrecognised JSON-LD context in representation data.</span></li>
+                </ul>
+
+                <p>When the subscription request returns notifications, the first part of the response provides information describing the <cite><a href="https://solidproject.org/TR/notifications-protocol#notification-channel" rel="cito:discusses">notification channel</a></cite> [<cite><a class="bibref" href="#bib-solid-notifications-protocol" >SOLID-NOTIFICATIONS-PROTOCOL</a></cite>]. Before serving <a href="#notification-message">notification messages</a>:</p>
+
+                <ul>
+                  <li about="" id="server-subscription-request-profile-unrecognised" rel="spec:requirement" resource="#server-subscription-request-profile-unrecognised"><span property="spec:statement">A <a href="#Server" rel="spec:requirementSubject">Server</a> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> transmit the description of the <cite><a href="https://solidproject.org/TR/notifications/streaming-http-channel-2023" rel="cito:discusses">streaming HTTP</a></cite> [<cite><a class="bibref" href="#bib-solid-streaming-http-channel-2023">SOLID-STREAMINGHTTPCHANNEL2023</a></cite>] <cite><a href="https://solidproject.org/TR/notifications-protocol#notification-channel" rel="cito:discusses">notification channel</a></cite> [<cite><a class="bibref" href="#bib-solid-notifications-protocol" >SOLID-NOTIFICATIONS-PROTOCOL</a></cite>] using the <a href="#notification-channel-data-model" rel="rdfs:seeAlso">Notification Channel Data Model</a> in the response content.</span></li>
+                </ul>
+
+                </div>
+              </section>
+
+              <section id="notifications" inlist="" rel="schema:hasPart" resource="#notifications">
+                <h3 property="schema:name">Notifications</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p>Unlike the <cite><a href="https://solidproject.org/TR/notifications-protocol" rel="cito:discusses">Solid Notifications Protocol</a></cite> [<cite><a class="bibref" href="#bib-solid-notifications-protocol" >SOLID-NOTIFICATIONS-PROTOCOL</a></cite>], the response to a <a href="#subscription">subscription</a> request also serves notifications. That is to say, the <cite><a href="https://solidproject.org/TR/notifications-protocol#subscription-service" rel="cito:discusses">subscription service</a></cite> doubles up as the <cite><a href="https://solidproject.org/TR/notifications-protocol#notification-channel" rel="cito:discusses">notification channel</a></cite>.</p>
+
+                  <p>Otherwise, the notification channel is identical to the <cite><a href="https://solidproject.org/TR/notifications/streaming-http-channel-2023" rel="cito:discusses">Solid StreamingHTTPChannel2023</a></cite> [<cite><a class="bibref" href="#bib-solid-streaming-http-channel-2023">SOLID-STREAMINGHTTPCHANNEL2023</a></cite>].</a></p>
+
+                  <figure class="example listing" id="notification-response-example" rel="schema:hasPart" resource="#notification-response-example">
+                    <figcaption property="schema:name"><span>Example</span>: <span>Notification Response.</span></figcaption>
+                    <pre property="schema:description">
+<code>HTTP/1.1 200 OK</code>
+<code>Accept-Query: "application/ld+json";</code>
+<code>  profile="http://www.w3.org/ns/json-ld#context https://www.w3.org/ns/solid/notifications-context/v1"</code>
+<code>Location: https://example.org/guinan/</code>
+<code>Content-Type: text/turtle</code>
+<code></code>
+<code>@prefix as: &lt;https://www.w3.org/ns/activitystreams#> .</code>
+<code>@prefix rdf: &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#> .</code>
+<code>@prefix notify: &lt;http://www.w3.org/ns/solid/notifications#> .</code>
+<code>@prefix xs: &lt;ttp://www.w3.org/2001/XMLSchema#> .</code>
+<code></code>
+<code>&lt;https://example.org/guinan/profile?notify=ac748712> notify:topic &lt;https://example.org/guinan/profile/> ;</code>
+<code>	notify:startAt "2023-01-01T07:00:00.000Z"^^xs:dateTime ;</code>
+<code>	notify:endAt "2023-01-01T09:00:00.000Z"^^xs:dateTime ;</code>
+<code>	notify:rate "PT5M"^^xs:duration ;</code>
+<code>	notify:state "e75-TFJH" .</code>
+<code></code>
+<code>&lt;urn:uuid:fc8b5af4-bd7e-4fd1-a649-afcbd0e1c083> as:object &lt;https://example.org/guinan/profile/> ;</code>
+<code>	notify:state "128f-MtYev" ;</code>
+<code>	as:published "2021-08-05T01:01:49.550Z"^^xs:dateTime ;</code>
+<code>	a as:Update .</code>
+<code></code>
+<code>&lt;urn:uuid:a4da6738-6be0-11ed-90bd-1be4ba6b6b33> as:object &lt;https://example.org/guinan/profile/image> ;</code>
+<code>	as:target &lt;https://example.org/guinan/profile/> ;</code>
+<code>	as:published "2022-11-24T11:55:31.483Z"^^xs:dateTime ;</code>
+<code>	a as:Add .</code></pre></figure>
+
+                  <p>To modify the response, a <a href="#Client" rel="spec:requirementSubject">Client</a> initiates a new <a href="#subscription">subscription</a> request with the <code>id</code> of the existing <cite><a href="https://solidproject.org/TR/notifications-protocol#notification-channel" rel="cito:discusses">notification channel</a></cite> and any modifications to it. If the request is successful, the <a href="#Client" rel="spec:requirementSubject">Client</a> will receive notifications in the response to the modifying <a href="#subscription">subscription</a> request. In such a case:</p>
+
+                  <ul>
+                    <li about="" id="server-subscription-modification-close-original" rel="spec:requirement" resource="#server-subscription-modification-close-original"><span property="spec:statement">A <a href="#Server" rel="spec:requirementSubject">Server</a> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> close the original response.</li>
+                    <li about="" id="server-subscription-modification-reuse-id" rel="spec:requirement" resource="#server-subscription-modification-reuse-id"><span property="spec:statement">A <a href="#Server" rel="spec:requirementSubject">Server</a> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> reuse the <code>id</code> from the description of the existing notification channel.</li>
+                  </ul>
+
+                </div>
+              </section>
+
+              <section id="notification-message" inlist="" rel="schema:hasPart" resource="#notification-message">
+                <h3 property="schema:name">Notification Message</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p>Notification Messages are identical to the <cite><a href="https://solidproject.org/TR/notifications-protocol#notification-message" rel="cito:discusses">Solid Notifications Protocol § 2.4</a></cite> [<cite><a class="bibref" href="#bib-solid-notifications-protocol">SOLID-NOTIFICATIONS-PROTOCOL</a></cite>]. Notification Messages are sent in the response after the description of the <cite><a href="https://solidproject.org/TR/notifications-protocol#notification-channel" rel="cito:discusses">notification channel</a></cite>.</p>
+                </div>
+              </section>
+            </div>
+          </section>
+
+          <section id="data-model" inlist="" rel="schema:hasPart" resource="#data-model">
+            <h2 property="schema:name">Data Model</h2>
+            <div datatype="rdf:HTML" property="schema:description">
+              <p>This section specifies any modifications to data models used in <cite><a href="https://solidproject.org/TR/notifications-protocol#data-model" rel="cito:discusses">Solid Notifications Protocol § 3</a></cite> [<cite><a class="bibref" href="#bib-solid-notifications-protocol">SOLID-NOTIFICATIONS-PROTOCOL</a></cite>].</p>
+
+              <section id="description-resource-data-model" inlist="" rel="schema:hasPart" resource="#description-resource-data-model">
+                <h3 content="Description Resource Data Model" property="schema:name">Description Resource</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p>The <cite><a href="https://solidproject.org/TR/notifications-protocol#description-resource">description resource</a></cite> [<cite><a class="bibref" href="#bib-solid-notifications-protocol">SOLID-NOTIFICATIONS-PROTOCOL</a></cite>] should additionally specify the following properties:</p>
+
+                  <ul>
+                    <li id="notify-query-http-subscription"><code rel="dcterms:subject" resource="http://www.w3.org/ns/solid/notifications#http-query-subscription">http-query-subscription</code> property to identify the available <a href="#subscription-service">HTTP QUERY subscription service</a>.</li>
+                  </ul>
+
+                  <figure class="example listing" id="description-resource-jsonld" rel="schema:hasPart" resource="#description-resource-jsonld">
+                    <figcaption property="schema:name"><span>Example</span>: Representation of a description resource.</figcaption>
+
+                    <pre datatype="rdf:JSON" property="schema:description"><code>{</code>
+<code>  "@context": [</code>
+<code>    "https://www.w3.org/ns/solid/notifications-context/v1"</code>
+<code>  ],</code>
+<code>  "id": "https://example.org/guinan/profile",</code>
+<code>  "http-query-subscription": {</code>
+<code>    "id": "https://example.org/guinan/",</code>
+<code>    "feature": ["endAt", "rate", "state"]</code>
+<code>  },</code>
+<code>  "subscription": [{</code>
+<code>    "id": "https://websocket.example/subscription",</code>
+<code>    "channelType": "WebSocketChannel2023",</code>
+<code>    "feature": ["endAt", "rate", "state"]</code>
+<code>  }],</code>
+<code>  "channel": [{</code>
+<code>    "id": "https://channel.example/guinan/profile",</code>
+<code>    "type": "WebSocketChannel2023",</code>
+<code>    "topic": "https://example.org/guinan/profile",</code>
+<code>    "receiveFrom": "wss://websocket.example/guinan/profile",</code>
+<code>    "rate": "PT1M"</code>
+<code>  }]</code>
+<code>}</code></pre>
+                  </figure>
+                </div>
+              </section>
+
+              <section id="subscription-service-data-model" inlist="" rel="schema:hasPart" resource="#subscription-service-data-model">
+                <h3 content="Subscription Service Data Model" property="schema:name">Subscription Service</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p>The Subscription Service Data Model is identical to the <cite><a href="https://solidproject.org/TR/notifications-protocol#subscription-service-data-model" rel="cito:discusses">Solid Notifications Protocol § 3.2</a></cite> [<cite><a class="bibref" href="#bib-solid-notifications-protocol" >SOLID-NOTIFICATIONS-PROTOCOL</a></cite>] except:</p>
+
+                  <ul>
+                    <li id="omit-channelType-subscription-service">The <code>channelType</code> property MUST be omitted.</li>
+                  </ul>
+
+                  <figure class="example listing" id="subscription-service-jsonld" rel="schema:hasPart" resource="#subscription-service-jsonld">
+                    <figcaption property="schema:name"><span>Example</span>: Representation of a subscription service.</figcaption>
+
+                    <pre datatype="rdf:JSON" property="schema:description"><code>{</code>
+<code>  "@context": [</code>
+<code>    "https://www.w3.org/ns/solid/notifications-context/v1"</code>
+<code>  ],</code>
+<code>  "id": "https://example.org/guinan/profile",</code>
+<code>  "feature": ["endAt", "rate", "state"]</code>
+<code>}</code></pre>
+                  </figure>
+                </div>
+              </section>
+
+              <section id="notification-channel-data-model" inlist="" rel="schema:hasPart" resource="#notification-channel-data-model">
+                <h3 content="Notification Channel Data Model" property="schema:name">Notification Channel</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p>The Notification Channel Data Model is identical to the <cite><a href="https://solidproject.org/TR/notifications-protocol#notification-channel-data-model" rel="cito:discusses">Solid Notifications Protocol § 3.3</a></cite> [<cite><a class="bibref" href="#bib-solid-notifications-protocol">SOLID-NOTIFICATIONS-PROTOCOL</a></cite>] for the <cite><a href="https://solidproject.org/TR/notifications/streaming-http-channel-2023" rel="cito:discusses">Solid StreamingHTTPChannel2023</a></cite> [<cite><a class="bibref" href="#bib-solid-streaming-http-channel-2023">SOLID-STREAMINGHTTPCHANNEL2023</a></cite>], except:</p>
+
+                  <ul>
+                    <li id="omit-channelType-notification-channel">The <code>channelType</code> property MUST be omitted.</li>
+                    <li id="omit-receiveFrom-notification-channel">The <code>receiveFrom</code> property MUST be omitted.</li>
+                  </ul>
+
+                </div>
+              </section>
+
+              <section id="notification-message-data-model" inlist="" rel="schema:hasPart" resource="#notification-message-data-model">
+                <h3 content="Notification Message Data Model" property="schema:name">Notification Message</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p>The Notification Message Data Model is identical to the <cite><a href="https://solidproject.org/TR/notifications-protocol#notification-message-data-model" rel="cito:discusses">Solid Notifications Protocol § 3.4</a></cite> [<cite><a class="bibref" href="#bib-solid-notifications-protocol">SOLID-NOTIFICATIONS-PROTOCOL</a></cite>].</p>
+                </div>
+              </section>
+            </div>
+          </section>
+
+          <section id="considerations" inlist="" rel="schema:hasPart" resource="#considerations" typeof="spec:Considerations">
+            <h2 property="schema:name">Considerations</h2>
+            <div datatype="rdf:HTML" property="schema:description">
+              <p>This section details <span about="" rel="spec:consideration"><a href="#security-considerations">security</a> and <a href="#privacy-considerations">privacy</a> considerations</span>.</p>
+
+              <p>Some of the normative references with this specification point to documents with a <em>Living Standard</em> or <em>Draft</em> status, meaning their contents can still change over time. It is advised to monitor these documents, as such changes might have implications.</p>
+
+              <section id="security-considerations" inlist="" rel="schema:hasPart" resource="#security-considerations" typeof="spec:SecurityConsiderations">
+                <h3 property="schema:name">Security Considerations</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p><em>This section is non-normative.</em></p>
+
+                  <p id="consider-exposing-information"><a href="#Server">Servers</a> are strongly discouraged from exposing information beyond the minimum amount necessary to enable a feature. <a href="#Client" rel="spec:requirementSubject">Clients</a> are strongly discouraged from exposing information beyond the minimum amount necessary to subscribe to updates about particular resources.</p>
+
+                  <p id="consider-subscription-service-trust"><a href="#Client" rel="spec:requirementSubject">Clients</a> are discouraged from sending subscription requests to untrusted subscription services, including localhost or any other loopback IP address, in order to avoid making arbitrary requests.</p>
+                </div>
+              </section>
+
+              <section id="privacy-considerations" inlist="" rel="schema:hasPart" resource="#privacy-considerations" typeof="spec:PrivacyConsiderations">
+                <h3 property="schema:name">Privacy Considerations</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p><em>This section is non-normative.</em></p>
+                </div>
+              </section>
+
+              <section id="security-privacy-review" inlist="" rel="schema:hasPart" resource="#security-privacy-review" typeof="spec:SelfReviewQuestionnaireSecurityPrivacy">
+                <h3 property="schema:name">Security and Privacy Review</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p><em>This section is non-normative.</em></p>
+
+                  <p>These questions provide an overview of security and privacy considerations for this specification as guided by [<cite><a class="bibref" href="#bib-security-privacy-questionnaire">SECURITY-PRIVACY-QUESTIONNAIRE</a></cite>].</p>
+
+                  <dl rel="schema:hasPart">
+                    <dt about="#security-privacy-review-purpose" id="security-privacy-review-purpose"><a href="https://www.w3.org/TR/security-privacy-questionnaire/#purpose" rel="cito:repliesTo">What information might this feature expose to Web sites or other parties, and for what purposes is that exposure necessary?</a></dt>
+                    <dd about="#security-privacy-review-purpose" datatype="rdf:HTML" property="schema:description">There are no known security impacts of the features in this specification.</dd>
+
+                    <dt about="#security-privacy-review-minimum-data" id="security-privacy-review-minimum-data"><a href="https://www.w3.org/TR/security-privacy-questionnaire/#minimum-data" rel="cito:repliesTo">Do features in your specification expose the minimum amount of information necessary to enable their intended uses?</a></dt>
+                    <dd about="#security-privacy-review-minimum-data" datatype="rdf:HTML" property="schema:description">Yes.</dd>
+
+                    <dt about="#security-privacy-review-personal-data" id="security-privacy-review-personal-data"><a href="https://www.w3.org/TR/security-privacy-questionnaire/#personal-data" rel="cito:repliesTo">How do the features in your specification deal with personal information, personally-identifiable information (PII), or information derived from them?</a></dt>
+                    <dd about="#security-privacy-review-personal-data" datatype="rdf:HTML" property="schema:description">Access to resources is only granted to authorized access subjects. The request and response content can contain any data (including that which identifies or refers to agents that control the <cite> <a href="#Client" rel="cito:discusses">Client</a></cite> and <cite><a href="#Server" rel="cito:discusses">Server</a></cite>.) <cite><a href="https://w3ctag.github.io/design-principles/#consent" rel="cito:obtainsBackgroundFrom">Meaningful consent</a></cite> to any personal data that Clients include about agents associated with themselves or <cite><a href="https://solidproject.org/TR/notifications-protocol#topic-resource">topic resources </a></cite> [<cite><a class="bibref" href="#bib-solid-notifications-protocol">SOLID-NOTIFICATIONS-PROTOCOL</a></cite>] of interest are extended to the <cite><a href="#Client" rel="cito:discusses">Client</a></cite>.  <cite><a href="#Client" rel="cito:discusses">Clients</a></cite> and <cite><a href="#Server" rel="cito:discusses">Servers</a></cite> are discouraged from exposing information beyond the amount necessary to enable or use a feature.</dd>
+
+                    <dt about="#security-privacy-review-sensitive-data" id="security-privacy-review-sensitive-data"><a href="https://www.w3.org/TR/security-privacy-questionnaire/#sensitive-data" rel="cito:repliesTo">How do the features in your specification deal with sensitive information?</a></dt>
+                    <dd about="#security-privacy-review-sensitive-data" datatype="rdf:HTML" property="schema:description">The features do not require sensitive information to obtained or exposed.</dd>
+
+                    <dt about="#security-privacy-review-persistent-origin-specific-state" id="security-privacy-review-persistent-origin-specific-state"><a href="https://www.w3.org/TR/security-privacy-questionnaire/#persistent-origin-specific-state" rel="cito:repliesTo">Do the features in your specification introduce new state for an origin that persists across browsing sessions?</a></dt>
+                    <dd about="#security-privacy-review-persistent-origin-specific-state" datatype="rdf:HTML" property="schema:description">No.</dd>
+
+                    <dt about="#security-privacy-review-underlying-platform-data" id="security-privacy-review-underlying-platform-data"><a href="https://www.w3.org/TR/security-privacy-questionnaire/#underlying-platform-data" rel="cito:repliesTo">Do the features in your specification expose information about the underlying platform to origins?</a></dt>
+                    <dd about="#security-privacy-review-underlying-platform-data" datatype="rdf:HTML" property="schema:description">No.</dd>
+
+                    <dt about="#security-privacy-review-send-to-platform" id="security-privacy-review-send-to-platform"><a href="https://www.w3.org/TR/security-privacy-questionnaire/#send-to-platform" rel="cito:repliesTo">Does this specification allow an origin to send data to the underlying platform?</a></dt>
+                    <dd about="#security-privacy-review-send-to-platform" datatype="rdf:HTML" property="schema:description">No. <cite><a href="#Server" rel="cito:discusses">Servers</a></cite> might be able to redirect to other resources, (e.g., the <code>https:</code> URLs to <code>file:</code>, <code>data:</code>, or <code>blob:</code> URLs), but no such behaviour is defined by this specification.</dd>
+
+                    <dt about="#security-privacy-review-sensor-data" id="security-privacy-review-sensor-data"><a href="https://www.w3.org/TR/security-privacy-questionnaire/#sensor-data" rel="cito:repliesTo">Do features in this specification allow an origin access to sensors on a user’s device</a></dt>
+                    <dd about="#security-privacy-review-sensor-data" datatype="rdf:HTML" property="schema:description">No.</dd>
+
+                    <dt about="#security-privacy-review-other-data" id="security-privacy-review-other-data"><a href="https://www.w3.org/TR/security-privacy-questionnaire/#other-data" rel="cito:repliesTo">What data do the features in this specification expose to an origin? Please also document what data is identical to data exposed by other features, in the same or different contexts.</a></dt>
+                    <dd about="#security-privacy-review-other-data" datatype="rdf:HTML" property="schema:description">No detail about another origin’s state is exposed. When servers participate in the <cite><a href="https://fetch.spec.whatwg.org/#cors-protocol" rel="cito:citesAsAuthority">CORS protocol</a></cite> [<cite><a class="bibref" href="#bib-fetch">FETCH</a></cite>], HTTP requests from different <cite><a href="https://datatracker.ietf.org/doc/html/rfc6454#section-2.3" rel="cito:citesAsAuthority">origins</a></cite> [<cite><a class="bibref" href="#bib-RFC6454">RFC6454</a></cite>] may be allowed. This feature does not add any new attack surface above and beyond normal <cite><a href="https://fetch.spec.whatwg.org/#cors-request" rel="cito:citesAsAuthority">CORS requests</a></cite>, so no extra mitigation is deemed necessary.</dd>
+
+                    <dt about="#security-privacy-review-string-to-script" id="security-privacy-review-string-to-script"><a href="https://www.w3.org/TR/security-privacy-questionnaire/#string-to-script" rel="cito:repliesTo">Do features in this specification enable new script execution/loading mechanisms?</a></dt>
+                    <dd about="#security-privacy-review-string-to-script" datatype="rdf:HTML" property="schema:description">No.</dd>
+
+                    <dt about="#security-privacy-review-remote-device" id="security-privacy-review-remote-device"><a href="https://www.w3.org/TR/security-privacy-questionnaire/#remote-device" rel="cito:repliesTo">Do features in this specification allow an origin to access other devices?</a></dt>
+                    <dd about="#security-privacy-review-remote-device" datatype="rdf:HTML" property="schema:description">No.</dd>
+
+                    <dt about="#security-privacy-review-native-ui" id="security-privacy-review-native-ui"><a href="https://www.w3.org/TR/security-privacy-questionnaire/#native-ui" rel="cito:repliesTo">Do features in this specification allow an origin some measure of control over a user agent’s native UI?</a></dt>
+                    <dd about="#security-privacy-review-native-ui" datatype="rdf:HTML" property="schema:description">No.</dd>
+
+                    <dt about="#security-privacy-review-temporary-id" id="security-privacy-review-temporary-id"><a href="https://www.w3.org/TR/security-privacy-questionnaire/#temporary-id" rel="cito:repliesTo">What temporary identifiers do the features in this specification create or expose to the web?</a></dt>
+                    <dd about="#security-privacy-review-temporary-id" datatype="rdf:HTML" property="schema:description">The <cite><a href="#subscription" rel="cito:discusses">subscription</a></cite> response content can contain an identifier for the notification channel which is only exposed to authorized <cite><a href="#Client" rel="cito:discusses"> Clients</a></cite>.</dd>
+
+                    <dt about="#security-privacy-review-first-third-party" id="security-privacy-review-first-third-party"><a href="https://www.w3.org/TR/security-privacy-questionnaire/#first-third-party" rel="cito:repliesTo">How does this specification distinguish between behaviour in first-party and third-party contexts?</a></dt>
+                    <dd about="#security-privacy-review-first-third-party" datatype="rdf:HTML" property="schema:description">Not Applicable.</dd>
+
+                    <dt about="#security-privacy-review-private-browsing" id="security-privacy-review-private-browsing"><a href="https://www.w3.org/TR/security-privacy-questionnaire/#private-browsing" rel="cito:repliesTo">How do the features in this specification work in the context of a browser’s Private Browsing or Incognito mode?</a></dt>
+                    <dd about="#security-privacy-review-private-browsing" datatype="rdf:HTML" property="schema:description">No different than in the <q cite="https://www.w3.org/TR/security-privacy-questionnaire/#private-browsing">browser’s 'normal' state</q>.</dd>
+
+                    <dt about="#security-privacy-review-considerations" id="security-privacy-review-considerations"><a href="https://www.w3.org/TR/security-privacy-questionnaire/#considerations" rel="cito:repliesTo">Does this specification have both "Security Considerations" and "Privacy Considerations" sections?</a></dt>
+                    <dd about="#security-privacy-review-considerations" datatype="rdf:HTML" property="schema:description">Yes, in <cite><a href="#security-considerations" rel="rdfs:seeAlso">Security Considerations</a></cite> and <cite><a href="#privacy-considerations" rel="rdfs:seeAlso">Privacy Considerations</a></cite>.</dd>
+
+                    <dt about="#security-privacy-review-relaxed-sop" id="security-privacy-review-relaxed-sop"><a href="https://www.w3.org/TR/security-privacy-questionnaire/#relaxed-sop" rel="cito:repliesTo">Do features in your specification enable origins to downgrade default security protections?</a></dt>
+                    <dd about="#security-privacy-review-relaxed-sop" datatype="rdf:HTML" property="schema:description">No.</dd>
+
+                    <dt about="#security-privacy-review-non-fully-active" id="security-privacy-review-non-fully-active"><a href="https://www.w3.org/TR/security-privacy-questionnaire/#non-fully-active" rel="cito:repliesTo">How does your feature handle non-"fully active" documents?</a></dt>
+                    <dd about="#security-privacy-review-non-fully-active" datatype="rdf:HTML" property="schema:description">Not Applicable.</dd>
+                  </dl>
+                </div>
+              </section>
+            </div>
+          </section>
+
+          <section class="appendix" id="changelog" inlist="" rel="schema:hasPart" resource="#changelog" typeof="spec:Changelog">
+            <h2 property="schema:name">Changelog</h2>
+            <div datatype="rdf:HTML" property="schema:description">
+              <p><em>This section is non-normative.</em></p>
+            </div>
+          </section>
+
+          <section class="appendix" id="acknowledgements" inlist="" rel="schema:hasPart" resource="#acknowledgements">
+            <h2 property="schema:name">Acknowledgements</h2>
+            <div datatype="rdf:HTML" property="schema:description">
+              <p>The Community Group gratefully acknowledges the work that led to the creation of this specification, and extends sincere appreciation to those individuals that worked on technologies and specifications that deeply influenced our work.</p>
+
+              <p>The Community Group would like to thank the following individuals for their useful comments, both large and small, that have led to changes to this specification over the years:</p>
+
+              <ul>
+                <li>Aaron Coburn</li>
+                <li>Ángel Araya</li>
+                <li>Christoph Braun</li>
+                <li>Dmitri Zagidulin</li>
+                <li>elf Palvlik</li>
+                <li>Graham Klyne</li>
+                <li>Hadrian Zbarcea</li>
+                <li>Henry Story</li>
+                <li>Jackson Morgan</li>
+                <li>Jamie Fiedler</li>
+                <li>Jarlath Holleran</li>
+                <li>Joachim Van Herwegen</li>
+                <li>Justin Bingham</li>
+                <li>Kevin Howard</li>
+                <li>Kjetil Kjernsmo</li>
+                <li>Michiel de Jong</li>
+                <li>Pete Edwards</li>
+                <li>Rahul Gupta</li>
+                <li>Ruben Verborgh</li>
+                <li>Sarven Capadisli</li>
+                <li>Ted Thibodeau Jr</li>
+                <li>Tim Berners-Lee</li>
+                <li>Wout Slabbinck</li>
+                <li>Wouter Termont</li>
+                <li><span lang="te" xml:lang="te">దామోదర</span></li>
+              </ul>
+            </div>
+          </section>
+
+          <section class="appendix" id="references" inlist="" rel="schema:hasPart" resource="#references">
+            <h2 property="schema:name">References</h2>
+            <div datatype="rdf:HTML" property="schema:description">
+              <section id="normative-references" inlist="" rel="schema:hasPart" resource="#normative-references">
+                <h3 property="schema:name">Normative References</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <dl class="bibliography" resource="">
+                    <dt id="bib-activitystreams-vocabulary">[ACTIVITYSTREAMS-VOCABULARY]</dt>
+                    <dd><cite><a href="https://www.w3.org/TR/activitystreams-vocabulary/" rel="cito:citesAsAuthority">Activity Streams</a></cite>. James Snell; Evan Prodromou.  W3C. 23 May 2017. W3C Recommendation. URL: <a href="https://www.w3.org/TR/activitystreams-vocabulary/">https://www.w3.org/TR/activitystreams-vocabulary/</a></dd>
+                    <dt id="bib-json-ld11">[JSON-LD11]</dt>
+                    <dd><cite><a href="https://www.w3.org/TR/json-ld11/" rel="cito:citesAsAuthority">JSON-LD 1.1</a></cite>. Gregg Kellogg; Pierre-Antoine Champin; Dave Longley.  W3C. 16 July 2020. W3C Recommendation. URL: <a href="https://www.w3.org/TR/json-ld11/">https://www.w3.org/TR/json-ld11/</a></dd>
+                    <dt id="bib-powder-dr">[POWDER-DR]</dt>
+                    <dd><cite><a href="https://www.w3.org/TR/powder-dr/" rel="cito:citesAsAuthority">Protocol for Web Description Resources (POWDER): Description Resources</a></cite>. Phil Archer; Kevin Smith; Andrea Perego.  W3C. 1 September 2009. W3C Recommendation. URL: <a href="https://www.w3.org/TR/powder-dr/">https://www.w3.org/TR/powder-dr/</a></dd>
+                    <dt id="bib-http-query">[HTTP-QUERY]</dt>
+                    <dd><cite><a href="https://httpwg.org/http-extensions/draft-ietf-httpbis-safe-method-w-body.html" rel="cito:citesAsAuthority">The HTTP QUERY Method</a></cite>. J. Reschke; J.M. Snell; M. Bishop. 4 April 2025. Internet Draft, HTTPWG. URL: <a href="https://httpwg.org/http-extensions/draft-ietf-httpbis-safe-method-w-body.html">https://httpwg.org/http-extensions/draft-ietf-httpbis-safe-method-w-body.html</a></dd>
+                    <dt id="bib-rdf11-concepts">[RDF11-CONCEPTS]</dt>
+                    <dd><cite><a href="https://www.w3.org/TR/rdf11-concepts/" rel="cito:citesAsAuthority">RDF 1.1 Concepts and Abstract Syntax</a></cite>. Richard Cyganiak; David Wood; Markus Lanthaler.  W3C. 25 February 2014. W3C Recommendation. URL: <a href="https://www.w3.org/TR/rdf11-concepts/">https://www.w3.org/TR/rdf11-concepts/</a></dd>
+                    <dt id="bib-rfc2119">[RFC2119]</dt>
+                    <dd><cite><a href="https://datatracker.ietf.org/doc/html/rfc2119" rel="cito:citesAsAuthority">Key words for use in RFCs to Indicate Requirement Levels</a></cite>. S. Bradner.  IETF. March 1997. Best Current Practice. URL: <a href="https://datatracker.ietf.org/doc/html/rfc2119">https://datatracker.ietf.org/doc/html/rfc2119</a></dd>
+                    <dt id="bib-rfc3986">[RFC3986]</dt>
+                    <dd><cite><a href="https://datatracker.ietf.org/doc/html/rfc3986" rel="cito:citesAsAuthority">Uniform Resource Identifier (URI): Generic Syntax</a></cite>. T. Berners-Lee; R. Fielding; L. Masinter.  IETF. January 2005. Internet Standard. URL: <a href="https://datatracker.ietf.org/doc/html/rfc3986">https://datatracker.ietf.org/doc/html/rfc3986</a></dd>
+                    <dt id="bib-rfc4918">[RFC4918]</dt>
+                    <dd><cite><a href="https://datatracker.ietf.org/doc/html/rfc4918" rel="cito:citesAsAuthority">HTTP Extensions for Web Distributed Authoring and Versioning (WebDAV)</a></cite>. L. Dusseault, Ed.  IETF. June 2007. Proposed Standard. URL: <a href="https://datatracker.ietf.org/doc/html/rfc4918">https://datatracker.ietf.org/doc/html/rfc4918</a></dd>
+                    <dt id="bib-rfc8174">[RFC8174]</dt>
+                    <dd><cite><a href="https://datatracker.ietf.org/doc/html/rfc8174" rel="cito:citesAsAuthority">Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words</a></cite>. B. Leiba.  IETF. May 2017. Best Current Practice. URL: <a href="https://datatracker.ietf.org/doc/html/rfc8174">https://datatracker.ietf.org/doc/html/rfc8174</a></dd>
+                    <dt id="bib-rfc8288">[RFC8288]</dt>
+                    <dd><cite><a href="https://httpwg.org/specs/rfc8288.html" rel="cito:citesAsAuthority">Web Linking</a></cite>. M. Nottingham.  IETF. October 2017. Proposed Standard. URL: <a href="https://httpwg.org/specs/rfc8288.html">https://httpwg.org/specs/rfc8288.html</a></dd>
+                    <dt id="bib-rfc9110">[RFC9110]</dt>
+                    <dd><cite><a href="https://www.rfc-editor.org/rfc/rfc9110" rel="cito:citesAsAuthority">HTTP Semantics</a></cite>. R. Fielding, M. Nottingham, J. Reschke, Eds.  IETF. June 2022. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc9110">https://www.rfc-editor.org/rfc/rfc9110</a></dd>
+                    <dt id="bib-rfc9112">[RFC9112]</dt>
+                    <dd><cite><a href="https://www.rfc-editor.org/rfc/rfc9112" rel="cito:citesAsAuthority">HTTP/1.1</a></cite>. R. Fielding, M. Nottingham, J. Reschke, Eds.  IETF. June 2022. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc9112">https://www.rfc-editor.org/rfc/rfc9112</a></dd>
+                    <dt id="bib-solid-notifications-protocol">[SOLID-NOTIFICATIONS-PROTOCOL]</dt>
+                    <dd><cite><a href="https://solidproject.org/TR/notifications-protocol" rel="cito:citesAsAuthority" typeof="doap:Specification">Solid Notifications Protocol</a></cite>. Sarven Capadisli et. al. W3C Solid Community Group. Draft Community Group Report, Version 0.4.0. URL: <a href="https://solidproject.org/TR/notifications-protocol">https://solidproject.org/TR/notifications-protocol</a></dd>
+                    <dt id="bib-solid-protocol">[SOLID-PROTOCOL]</dt>
+                    <dd><cite><a href="https://solidproject.org/TR/protocol" rel="cito:citesAsAuthority" typeof="doap:Specification">Solid Protocol</a></cite>. Sarven Capadisli; Tim Berners-Lee; Kjetil Kjernsmo.  W3C Solid Community Group. Draft Community Group Report, Version 0.11.0. URL: <a href="https://solidproject.org/TR/protocol">https://solidproject.org/TR/protocol</a></dd>
+                    <dt id="bib-solid-streaming-http-channel-2023">[SOLID-STREAMINGHTTPCHANNEL2023]</dt>
+                    <dd><cite><a href="https://solidproject.org/TR/protocol" rel="cito:citesAsAuthority" typeof="doap:Specification">Solid StreamingHTTPChannel2023</a></cite>. elf Pavlik. W3C Solid Community Group. Draft Community Group Report, Version 0.1.0. URL: <a href="https://solidproject.org/TR/streaming-http-channel-2023">https://solidproject.org/TR/streaming-http-channel-2023</a></dd>
+                    <dt id="bib-xmlschema11-2">[XMLSCHEMA11-2]</dt>
+                    <dd><cite><a href="https://www.w3.org/TR/xmlschema11-2/" rel="cito:citesAsAuthority">W3C XML Schema Definition Language (XSD) 1.1 Part 2: Datatypes</a></cite>. David Peterson; Sandy Gao; Ashok Malhotra; Michael Sperberg-McQueen; Henry Thompson; Paul V. Biron et al.  W3C. 5 April 2012. W3C Recommendation. URL: <a href="https://www.w3.org/TR/xmlschema11-2/">https://www.w3.org/TR/xmlschema11-2/</a></dd>
+                  </dl>
+                </div>
+              </section>
+
+              <section id="informative-references" inlist="" rel="schema:hasPart" resource="#informative-references">
+                <h3 property="schema:name">Informative References</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <dl class="bibliography" resource="">
+                    <dt id="bib-solid-technical-reports">[SOLID-TECHNICAL-REPORTS]</dt>
+                    <dd><cite><a href="https://solidproject.org/TR/" rel="cito:citesAsRelated">Solid Technical Reports</a></cite>. Sarven Capadisli.  W3C Solid Community Group. 03 June 2024. Living Document. URL: <a href="https://solidproject.org/TR/">https://solidproject.org/TR/</a></dd>
+                    <dt id="bib-notifications-ucr">[NOTIFICATIONS-UCR]</dt>
+                    <dd><cite><a href="https://solid.github.io/notifications-panel/notifications-ucr" rel="cito:citesAsRelated">Solid Notifications Use Cases and Requirements</a></cite>. Sarven Capadisli.  W3C Solid Community Group. 28 November 2022. W3C Editor’s Draft. URL: <a href="https://solid.github.io/notifications-panel/notifications-ucr">https://solid.github.io/notifications-panel/notifications-ucr</a></dd>
+                    <dt id="bib-security-privacy-questionnaire">[SECURITY-PRIVACY-QUESTIONNAIRE]</dt>
+                    <dd><cite><a href="https://www.w3.org/TR/security-privacy-questionnaire/" rel="cito:citesAsPotentialSolution">Self-Review Questionnaire: Security and Privacy</a></cite>. Theresa O'Connor; Peter Snyder.  W3C. 16 December 2021. W3C Group Note. URL: <a href="https://www.w3.org/TR/security-privacy-questionnaire/">https://www.w3.org/TR/security-privacy-questionnaire/</a></dd>
+                    <dt id="bib-w3c-process">[W3C-PROCESS]</dt>
+                    <dd><cite><a href="https://www.w3.org/policies/process/" rel="cito:citesAsPotentialSolution">W3C Process Document</a></cite>. Elika J. Etemad / fantasai; Florian Rivoal.  W3C Process Community Group. 12 June 2023. URL: <a href="https://www.w3.org/policies/process/">https://www.w3.org/policies/process/</a></dd>
+                  </dl>
+                </div>
+              </section>
+            </div>
+          </section>
+        </div>
+      </article>
+    </main>
+
+    <p role="navigation" id="back-to-top"><a href="#toc"><abbr title="Back to top">↑</abbr></a></p>
+
+    <script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
Adds HTTP Query Notifications Protocol extends the Solid Notifications Protocol for streaming HTTP notifications that take advantage of the newly proposed QUERY method to combine the subscription for and the receipt of notifications into a single HTTP request/response round-trip.

This proposal is yet another attempt to resolve the issues raised in #110 as well as the concern raised in the [notification panel meeting on 12-01-2023](https://github.com/solid/notifications-panel/blob/main/meetings/2023-01-12.md). Not only is this spec much simpler, it is completely compatible with Solid Notifications and can be alongside the existing specification.

[HTML Preview](https://htmlpreview.github.io/?https://github.com/CxRes/notifications/blob/shq/shq-protocol.html)